### PR TITLE
Make the RHAI variables more detailed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,19 @@ Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evalua
 
 ### Server counts, detailed variables
 
-- `stratum0_ok`: The number of stratum0 servers with status OK
+- `stratum0_ok`: The number of stratum0 servers with status OK (legacy: `stratum0_servers`)
 - `stratum0_degraded`: The number of stratum0 servers with status DEGRADED
 - `stratum0_warning`: The number of stratum0 servers with status WARNING
 - `stratum0_failed`: The number of stratum0 servers with status FAILED
 - `stratum0_total`: The total number of stratum0 servers scraped (should equal stratum0_ok + stratum0_degraded + stratum0_warning + stratum0_failed)
 
-- `stratum1_ok`: The number of stratum1 servers with status OK
+- `stratum1_ok`: The number of stratum1 servers with status OK (legacy: `stratum1_servers`)
 - `stratum1_degraded`: The number of stratum1 servers with status DEGRADED
 - `stratum1_warning`: The number of stratum1 servers with status WARNING
 - `stratum1_failed`: The number of stratum1 servers with status FAILED
 - `stratum1_total`: The total number of stratum1 servers scraped (should equal stratum1_ok + stratum1_degraded + stratum1_warning + stratum1_failed)
 
-- `syncserver_ok`: The number of sync servers with status OK
+- `syncserver_ok`: The number of sync servers with status OK (legacy: `sync_servers`)
 - `syncserver_degraded`: The number of sync servers with status DEGRADED
 - `syncserver_warning`: The number of sync servers with status WARNING
 - `syncserver_failed`: The number of sync servers with status FAILED
@@ -128,19 +128,19 @@ Imagine these conditions for the overall status, `eessi_status`:
     "conditions": [
         {
             "status": "FAILED",
-            "when": "stratum1_servers == 0"
+            "when": "stratum1_ok == 0"
         },
         {
             "status": "WARNING",
-            "when": "stratum0_servers == 0 && stratum1_servers > 1"
+            "when": "stratum0_ok == 0 && stratum1_ok > 1"
         },
         {
             "status": "WARNING",
-            "when": "sync_servers == 0 && stratum1_servers > 1"
+            "when": "syncserver_ok == 0 && stratum1_ok > 1"
         },
         {
             "status": "DEGRADED",
-            "when": "stratum0_servers == 1 && stratum1_servers == 1"
+            "when": "stratum0_ok == 1 && ( stratum1_warning + stratum1_degraded + stratum1_failed ) > 0"
         },
         {
             "status": "DEGRADED",
@@ -148,7 +148,7 @@ Imagine these conditions for the overall status, `eessi_status`:
         },
         {
             "status": "OK",
-            "when": "stratum0_servers > 0 && stratum1_servers > 1 && sync_servers > 0"
+            "when": "stratum0_ok > 0 && stratum1_ok > 1 && syncserver_ok > 0"
         }
     ]
 }
@@ -159,7 +159,7 @@ In this example, as the rules are applied in order, the engine will check, in or
 1. If there are no stratum1 servers online, the status is set to `FAILED`.
 2. If there are no stratum0 servers online and more than one stratum1 server, the status is set to `WARNING`.
 3. If there are no sync servers online and more than one stratum1 server, the status is set to `WARNING`.
-4. If the stratum0 server is online and only one stratum1 server was found, the status is set to `DEGRADED`.
+4. If the stratum0 server is online and any stratum1 server has the status degraded, warning, or failed, the status is set to `DEGRADED`.
 5. If more than one repository is out of sync, the status is set to `DEGRADED`.
 6. If there is at least one stratum0 server, more than one stratum1 server, and at least one sync server, the status is set to `OK`.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are four supported status conditions that are evaluated:
 
 Each of these status conditions can have any number of rules associated with them, each with a `status` key that can be set to `OK`, `DEGRADED`, `WARNING`, or `FAILED`. The rules are evaluated in order, and the first matching rule will set the status for the condition in question.
 
-Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evaluated in order. The first matching rule will set the given status for the case in question. Valid variables for the conditions are:
+Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evaluated in order. The first matching rule will set the given status for the case in question. All condition groups use the same variable scope, so these variables are valid in rules for `eessi_status`, `stratum0_servers`, `stratum1_servers`, and `sync_servers`:
 
 ### Repository related
 
@@ -91,9 +91,9 @@ Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evalua
 
 ### Server counts, legacy variables
 
-- `stratum0_servers`: The number of stratum0 servers successfully scraped with a state of OK
-- `stratum1_servers`: The number of stratum1 servers successfully scraped with a state of OK
-- `sync_servers`: The number of sync servers successfully scraped with a state of OK
+- `stratum0_servers`: The number of stratum0 servers successfully scraped with status OK
+- `stratum1_servers`: The number of stratum1 servers successfully scraped with status OK
+- `sync_servers`: The number of sync servers successfully scraped with status OK
 
 ### Server counts, detailed variables
 

--- a/README.md
+++ b/README.md
@@ -101,19 +101,22 @@ Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evalua
 - `stratum0_degraded`: The number of stratum0 servers with status DEGRADED
 - `stratum0_warning`: The number of stratum0 servers with status WARNING
 - `stratum0_failed`: The number of stratum0 servers with status FAILED
-- `stratum0_total`: The total number of stratum0 servers scraped (should equal stratum0_ok + stratum0_degraded + stratum0_warning + stratum0_failed)
+- `stratum0_maintenance`: The number of stratum0 servers with status MAINTENANCE
+- `stratum0_total`: The total number of stratum0 servers scraped (should equal stratum0_ok + stratum0_degraded + stratum0_warning + stratum0_failed + stratum0_maintenance)
 
 - `stratum1_ok`: The number of stratum1 servers with status OK (legacy: `stratum1_servers`)
 - `stratum1_degraded`: The number of stratum1 servers with status DEGRADED
 - `stratum1_warning`: The number of stratum1 servers with status WARNING
 - `stratum1_failed`: The number of stratum1 servers with status FAILED
-- `stratum1_total`: The total number of stratum1 servers scraped (should equal stratum1_ok + stratum1_degraded + stratum1_warning + stratum1_failed)
+- `stratum1_maintenance`: The number of stratum1 servers with status MAINTENANCE
+- `stratum1_total`: The total number of stratum1 servers scraped (should equal stratum1_ok + stratum1_degraded + stratum1_warning + stratum1_failed + stratum1_maintenance)
 
 - `syncserver_ok`: The number of sync servers with status OK (legacy: `sync_servers`)
 - `syncserver_degraded`: The number of sync servers with status DEGRADED
 - `syncserver_warning`: The number of sync servers with status WARNING
 - `syncserver_failed`: The number of sync servers with status FAILED
-- `syncserver_total`: The total number of sync servers scraped (should equal syncserver_ok + syncserver_degraded + syncserver_warning + syncserver_failed)
+- `syncserver_maintenance`: The number of sync servers with status MAINTENANCE
+- `syncserver_total`: The total number of sync servers scraped (should equal syncserver_ok + syncserver_degraded + syncserver_warning + syncserver_failed + syncserver_maintenance)
 
 Note: It's `syncserver` (no underscore and singular, like stratum0/1).
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,38 @@ Each of these status conditions can have any number of rules associated with the
 
 Rules for conditions are evaluated using [Rhai](https://rhai.rs), and are evaluated in order. The first matching rule will set the given status for the case in question. Valid variables for the conditions are:
 
-- `stratum0_servers`: The number of stratum0 servers successfully scraped
-- `stratum1_servers`: The number of stratum1 servers successfully scraped
-- `sync_servers`: The number of sync servers successfully scraped
-- `repos_out_of_sync`: The number of repositories out of sync across all servers scraped
+### Repository related
+
+- `repos_out_of_sync`: The number of unique repositories out of sync across all servers scraped
+- `repos_total`: The total number of unique repositories scraped across all servers
+
+### Server counts, legacy variables
+
+- `stratum0_servers`: The number of stratum0 servers successfully scraped with a state of OK
+- `stratum1_servers`: The number of stratum1 servers successfully scraped with a state of OK
+- `sync_servers`: The number of sync servers successfully scraped with a state of OK
+
+### Server counts, detailed variables
+
+- `stratum0_ok`: The number of stratum0 servers with status OK
+- `stratum0_degraded`: The number of stratum0 servers with status DEGRADED
+- `stratum0_warning`: The number of stratum0 servers with status WARNING
+- `stratum0_failed`: The number of stratum0 servers with status FAILED
+- `stratum0_total`: The total number of stratum0 servers scraped (should equal stratum0_ok + stratum0_degraded + stratum0_warning + stratum0_failed)
+
+- `stratum1_ok`: The number of stratum1 servers with status OK
+- `stratum1_degraded`: The number of stratum1 servers with status DEGRADED
+- `stratum1_warning`: The number of stratum1 servers with status WARNING
+- `stratum1_failed`: The number of stratum1 servers with status FAILED
+- `stratum1_total`: The total number of stratum1 servers scraped (should equal stratum1_ok + stratum1_degraded + stratum1_warning + stratum1_failed)
+
+- `syncserver_ok`: The number of sync servers with status OK
+- `syncserver_degraded`: The number of sync servers with status DEGRADED
+- `syncserver_warning`: The number of sync servers with status WARNING
+- `syncserver_failed`: The number of sync servers with status FAILED
+- `syncserver_total`: The total number of sync servers scraped (should equal syncserver_ok + syncserver_degraded + syncserver_warning + syncserver_failed)
+
+Note: It's `syncserver` (no underscore and singular, like stratum0/1).
 
 ### Example of rules
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,8 +114,8 @@ async fn create_status_manager(config_manager: &config::ConfigManager) -> Result
 
     for server in &config.servers {
         let hostname = server.hostname.clone();
-        let backend = server.backend_type.clone();
-        let server_type = server.server_type.clone();
+        let backend = server.backend_type;
+        let server_type = server.server_type;
         servers.push(cvmfs_server_scraper::Server::new(
             server_type,
             backend,

--- a/src/models.rs
+++ b/src/models.rs
@@ -478,7 +478,7 @@ impl StatusManager {
         let mut scope = Scope::new();
         let engine = Engine::new();
 
-        for server_type in vec![
+        for server_type in [
             ServerType::Stratum0,
             ServerType::Stratum1,
             ServerType::SyncServer,
@@ -497,16 +497,10 @@ impl StatusManager {
                     status.as_ref().to_lowercase()
                 );
                 total += count;
-                println!("Adding to scope: {} = {}", key, count);
                 scope.push(&key, count);
             }
 
-            scope.push(&format!("{}_total", server_type.to_label()), total);
-            println!(
-                "Adding to scope: {} = {}",
-                format!("{}_total", server_type.to_label()),
-                total
-            );
+            scope.push(format!("{}_total", server_type.to_label()), total);
         }
 
         scope.push(
@@ -644,6 +638,15 @@ mod tests {
                 metadata: None,
             },
             Server {
+                server_type: ServerType::Stratum0,
+                backend_type: ServerBackendType::CVMFS,
+                backend_detected: Some(ServerBackendType::CVMFS),
+                hostname: Hostname::from_str("stratum0-maintenance.example.com").unwrap(),
+                repositories: vec![],
+                status: Status::MAINTENANCE,
+                metadata: None,
+            },
+            Server {
                 server_type: ServerType::Stratum1,
                 backend_type: ServerBackendType::AutoDetect,
                 backend_detected: Some(ServerBackendType::CVMFS),
@@ -751,7 +754,7 @@ mod tests {
     }
 
     #[parameterized(
-        stratum0 = { "stratum0", 1 },
+        stratum0 = { "stratum0", 2 },
         stratum1 = { "stratum1", 2 },
         syncserver = { "syncserver", 1 }
 
@@ -760,7 +763,7 @@ mod tests {
         let status_manager = create_status_manager();
 
         let when = format!(
-            "{server_type}_ok + {server_type}_degraded + {server_type}_warning + {server_type}_failed == {server_type}_total",
+            "{server_type}_ok + {server_type}_degraded + {server_type}_warning + {server_type}_failed + {server_type}_maintenance == {server_type}_total",
         );
 
         let conditions = vec![Condition {

--- a/src/models.rs
+++ b/src/models.rs
@@ -478,6 +478,37 @@ impl StatusManager {
         let mut scope = Scope::new();
         let engine = Engine::new();
 
+        for server_type in vec![
+            ServerType::Stratum0,
+            ServerType::Stratum1,
+            ServerType::SyncServer,
+        ] {
+            let mut total = 0;
+
+            for status in Status::iter() {
+                let count = self
+                    .get_by_status(status)
+                    .iter()
+                    .filter(|s| s.server_type == server_type)
+                    .count() as i64;
+                let key = format!(
+                    "{}_{}",
+                    server_type.to_label(),
+                    status.as_ref().to_lowercase()
+                );
+                total += count;
+                println!("Adding to scope: {} = {}", key, count);
+                scope.push(&key, count);
+            }
+
+            scope.push(&format!("{}_total", server_type.to_label()), total);
+            println!(
+                "Adding to scope: {} = {}",
+                format!("{}_total", server_type.to_label()),
+                total
+            );
+        }
+
         scope.push(
             "stratum0_servers",
             self.get_by_type_ok(ServerType::Stratum0).len() as i64,
@@ -493,6 +524,11 @@ impl StatusManager {
             self.get_by_type_ok(ServerType::SyncServer).len() as i64,
         );
 
+        scope.push(
+            "repos_total",
+            self.get_status_per_unique_repo().len() as i64,
+        );
+
         let not_ok_repos = self
             .get_status_per_unique_repo()
             .iter()
@@ -503,6 +539,7 @@ impl StatusManager {
 
         for condition in conditions {
             debug!("Evaluating condition: {:?}", condition);
+
             if evaluate_condition(&condition, &mut scope, &engine) {
                 return condition.status;
             }
@@ -555,9 +592,13 @@ fn compare_with_stratum0(
 }
 
 fn evaluate_condition(condition: &Condition, scope: &mut Scope, engine: &Engine) -> bool {
-    engine
-        .eval_expression_with_scope::<bool>(scope, &condition.when)
-        .unwrap_or(false)
+    match engine.eval_expression_with_scope::<bool>(scope, &condition.when) {
+        Ok(result) => result,
+        Err(e) => {
+            debug!("Failed to evaluate condition '{}': {}", condition.when, e);
+            false
+        }
+    }
 }
 
 fn evaluate_conditions_with_key_value(
@@ -580,4 +621,161 @@ fn evaluate_conditions_with_key_value(
         })
         .find(|&condition| evaluate_condition(condition, &mut scope, &engine))
         .map_or(Status::FAILED, |condition| condition.status)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use yare::parameterized;
+
+    use cvmfs_server_scraper::Hostname;
+
+    fn create_status_manager() -> StatusManager {
+        let servers = vec![
+            Server {
+                server_type: ServerType::Stratum0,
+                backend_type: ServerBackendType::CVMFS,
+                backend_detected: Some(ServerBackendType::CVMFS),
+                hostname: Hostname::from_str("stratum0.example.com").unwrap(),
+                repositories: vec![],
+                status: Status::OK,
+                metadata: None,
+            },
+            Server {
+                server_type: ServerType::Stratum1,
+                backend_type: ServerBackendType::AutoDetect,
+                backend_detected: Some(ServerBackendType::CVMFS),
+                hostname: Hostname::from_str("stratum1-auto-cvmfs-degraded.example.com").unwrap(),
+                repositories: vec![],
+                status: Status::DEGRADED,
+                metadata: None,
+            },
+            Server {
+                server_type: ServerType::Stratum1,
+                backend_type: ServerBackendType::CVMFS,
+                backend_detected: Some(ServerBackendType::CVMFS),
+                hostname: Hostname::from_str("stratum1-cvmfs-cvmfs-ok.example.com").unwrap(),
+                repositories: vec![],
+                status: Status::OK,
+                metadata: None,
+            },
+            Server {
+                server_type: ServerType::SyncServer,
+                backend_type: ServerBackendType::CVMFS,
+                backend_detected: Some(ServerBackendType::CVMFS),
+                hostname: Hostname::from_str("syncserver.example.com").unwrap(),
+                repositories: vec![],
+                status: Status::OK,
+                metadata: None,
+            },
+        ];
+
+        StatusManager { servers }
+    }
+
+    fn create_conditions_overall_legacy() -> Vec<Condition> {
+        vec![
+            Condition {
+                when: "stratum0_servers >= 1 && stratum1_servers >= 2".to_string(),
+                status: Status::OK,
+            },
+            Condition {
+                when: "stratum0_servers >= 1 && stratum1_servers >= 1".to_string(),
+                status: Status::DEGRADED,
+            },
+            Condition {
+                when: "stratum0_servers >= 1".to_string(),
+                status: Status::WARNING,
+            },
+        ]
+    }
+
+    fn create_conditions_overall_new() -> Vec<Condition> {
+        vec![
+            Condition {
+                when: "stratum0_ok >= 1 && stratum1_ok >= 2".to_string(),
+                status: Status::OK,
+            },
+            Condition {
+                when: "stratum0_ok >= 1 && stratum1_ok >= 1".to_string(),
+                status: Status::DEGRADED,
+            },
+            Condition {
+                when: "stratum0_ok >= 1".to_string(),
+                status: Status::WARNING,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_status_ordering() {
+        assert!(Status::OK < Status::DEGRADED);
+        assert!(Status::DEGRADED < Status::WARNING);
+        assert!(Status::WARNING < Status::FAILED);
+        assert!(Status::FAILED < Status::MAINTENANCE);
+    }
+
+    #[test]
+    fn test_conditions_overall_legacy() {
+        let status_manager = create_status_manager();
+        let conditions = create_conditions_overall_legacy();
+        let overall_status = status_manager.evaluate_overall_conditions(conditions);
+        assert_eq!(overall_status, Status::DEGRADED);
+    }
+
+    #[test]
+    fn test_conditions_overall_new() {
+        let status_manager = create_status_manager();
+        let conditions = create_conditions_overall_new();
+        let overall_status = status_manager.evaluate_overall_conditions(conditions);
+        assert_eq!(overall_status, Status::DEGRADED);
+    }
+
+    #[test]
+    fn test_conditions_invalid_key_is_ignored() {
+        let status_manager = create_status_manager();
+        let conditions = vec![
+            Condition {
+                when: "invalid_key >= 1".to_string(),
+                status: Status::OK,
+            },
+            Condition {
+                when: "stratum0_ok <= 1".to_string(),
+                status: Status::DEGRADED,
+            },
+        ];
+        let overall_status = status_manager.evaluate_overall_conditions(conditions);
+        assert_eq!(overall_status, Status::DEGRADED);
+    }
+
+    #[parameterized(
+        stratum0 = { "stratum0", 1 },
+        stratum1 = { "stratum1", 2 },
+        syncserver = { "syncserver", 1 }
+
+    )]
+    fn test_conditions_totals_equals_all_others(server_type: &str, count: usize) {
+        let status_manager = create_status_manager();
+
+        let when = format!(
+            "{server_type}_ok + {server_type}_degraded + {server_type}_warning + {server_type}_failed == {server_type}_total",
+        );
+
+        let conditions = vec![Condition {
+            when,
+            status: Status::OK,
+        }];
+        let overall_status = status_manager.evaluate_overall_conditions(conditions);
+        assert_eq!(overall_status, Status::OK);
+
+        let when = format!("{count} == {server_type}_total",);
+        let conditions = vec![Condition {
+            when,
+            status: Status::OK,
+        }];
+        let overall_status = status_manager.evaluate_overall_conditions(conditions);
+        assert_eq!(overall_status, Status::OK);
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -390,22 +390,14 @@ impl StatusManager {
 
     pub fn status_stratum1(&self, conditions: Vec<Condition>) -> Status {
         debug!("Conditions for stratum1s: {:?}", conditions.len());
-        let status = evaluate_conditions_with_key_value(
-            conditions,
-            "stratum1_servers",
-            self.get_by_type_ok(ServerType::Stratum1).len(),
-        );
+        let status = self.evaluate_conditions_with_full_scope(conditions);
         info!("Stratum1 status: {:?}", status);
         status
     }
 
     pub fn status_stratum0(&self, conditions: Vec<Condition>) -> Status {
         debug!("Conditions for stratum0s: {:?}", conditions.len());
-        let status = evaluate_conditions_with_key_value(
-            conditions,
-            "stratum0_servers",
-            self.get_by_type_ok(ServerType::Stratum0).len(),
-        );
+        let status = self.evaluate_conditions_with_full_scope(conditions);
         info!("Stratum0 status: {:?}", status);
         status
     }
@@ -430,11 +422,7 @@ impl StatusManager {
 
     pub fn status_syncserver(&self, conditions: Vec<Condition>) -> Status {
         debug!("Conditions for syncservers: {:?}", conditions.len());
-        let status = evaluate_conditions_with_key_value(
-            conditions,
-            "sync_servers",
-            self.get_by_type_ok(ServerType::SyncServer).len(),
-        );
+        let status = self.evaluate_conditions_with_full_scope(conditions);
         info!("Syncserver status: {:?}", status);
         status
     }
@@ -472,8 +460,18 @@ impl StatusManager {
     }
 
     fn evaluate_overall_conditions(&self, conditions: Vec<Condition>) -> Status {
-        let mut scope = Scope::new();
+        self.evaluate_conditions_with_full_scope(conditions)
+    }
+
+    fn evaluate_conditions_with_full_scope(&self, conditions: Vec<Condition>) -> Status {
+        let mut scope = self.build_condition_scope();
         let engine = Engine::new();
+
+        evaluate_conditions(conditions, &mut scope, &engine)
+    }
+
+    fn build_condition_scope(&self) -> Scope<'static> {
+        let mut scope = Scope::new();
 
         for server_type in [
             ServerType::Stratum0,
@@ -500,6 +498,8 @@ impl StatusManager {
             scope.push(format!("{}_total", server_type.to_label()), total);
         }
 
+        let repo_status = self.get_status_per_unique_repo();
+
         scope.push(
             "stratum0_servers",
             self.get_by_type_ok(ServerType::Stratum0).len() as i64,
@@ -515,28 +515,13 @@ impl StatusManager {
             self.get_by_type_ok(ServerType::SyncServer).len() as i64,
         );
 
-        scope.push(
-            "repos_total",
-            self.get_status_per_unique_repo().len() as i64,
-        );
+        scope.push("repos_total", repo_status.len() as i64);
 
-        let not_ok_repos = self
-            .get_status_per_unique_repo()
-            .iter()
-            .filter(|r| r.1 != &Status::OK)
-            .count() as i64;
+        let not_ok_repos = repo_status.iter().filter(|r| r.1 != &Status::OK).count() as i64;
 
         scope.push("repos_out_of_sync", not_ok_repos);
 
-        for condition in conditions {
-            debug!("Evaluating condition: {:?}", condition);
-
-            if evaluate_condition(&condition, &mut scope, &engine) {
-                return condition.status;
-            }
-        }
-
-        Status::FAILED
+        scope
     }
 }
 
@@ -592,25 +577,13 @@ fn evaluate_condition(condition: &Condition, scope: &mut Scope, engine: &Engine)
     }
 }
 
-fn evaluate_conditions_with_key_value(
-    conditions: Vec<Condition>,
-    key: &str,
-    value: usize,
-) -> Status {
-    let mut scope = Scope::new();
-    scope.push(key, value as i64);
-
-    let engine = Engine::new();
-
+fn evaluate_conditions(conditions: Vec<Condition>, scope: &mut Scope, engine: &Engine) -> Status {
     conditions
         .iter()
         .inspect(|condition| {
-            debug!(
-                "Evaluating condition: {:?} (key: <{:?}>, val <{:?}>)",
-                condition, key, value
-            );
+            debug!("Evaluating condition: {:?}", condition);
         })
-        .find(|&condition| evaluate_condition(condition, &mut scope, &engine))
+        .find(|&condition| evaluate_condition(condition, scope, engine))
         .map_or(Status::FAILED, |condition| condition.status)
 }
 
@@ -731,6 +704,46 @@ mod tests {
         let conditions = create_conditions_overall_new();
         let overall_status = status_manager.evaluate_overall_conditions(conditions);
         assert_eq!(overall_status, Status::DEGRADED);
+    }
+
+    #[test]
+    fn test_stratum1_conditions_can_use_detailed_variables() {
+        let status_manager = create_status_manager();
+        let conditions = vec![
+            Condition {
+                when: "stratum1_degraded == 1 && stratum1_total == 2".to_string(),
+                status: Status::DEGRADED,
+            },
+            Condition {
+                when: "stratum1_ok == 1".to_string(),
+                status: Status::OK,
+            },
+        ];
+
+        assert_eq!(status_manager.status_stratum1(conditions), Status::DEGRADED);
+    }
+
+    #[test]
+    fn test_stratum0_conditions_can_use_legacy_and_detailed_variables() {
+        let status_manager = create_status_manager();
+        let conditions = vec![Condition {
+            when: "stratum0_servers == 1 && stratum0_maintenance == 1 && stratum0_total == 2"
+                .to_string(),
+            status: Status::WARNING,
+        }];
+
+        assert_eq!(status_manager.status_stratum0(conditions), Status::WARNING);
+    }
+
+    #[test]
+    fn test_syncserver_conditions_can_use_detailed_variables() {
+        let status_manager = create_status_manager();
+        let conditions = vec![Condition {
+            when: "syncserver_ok == 1 && syncserver_total == 1".to_string(),
+            status: Status::OK,
+        }];
+
+        assert_eq!(status_manager.status_syncserver(conditions), Status::OK);
     }
 
     #[test]


### PR DESCRIPTION
## Drastically improve the variables exposed to the evaluation engine.

### Repository related

- `repos_out_of_sync`: The number of unique repositories out of sync across all servers scraped
- `repos_total`: The total number of unique repositories scraped across all servers (NEW!)

### Server counts, legacy variables

- `stratum0_servers`: The number of stratum0 servers successfully scraped with a state of OK
- `stratum1_servers`: The number of stratum1 servers successfully scraped with a state of OK
- `sync_servers`: The number of sync servers successfully scraped with a state of OK

### Server counts, detailed variables (NEW!)

#### Stratum0

- `stratum0_ok`: The number of stratum0 servers with status OK (legacy equivalent: `stratum0_servers`)
- `stratum0_degraded`: The number of stratum0 servers with status DEGRADED
- `stratum0_warning`: The number of stratum0 servers with status WARNING
- `stratum0_failed`: The number of stratum0 servers with status FAILED
- `stratum0_total`: The total number of stratum0 servers scraped (should equal stratum0_ok + stratum0_degraded + stratum0_warning + stratum0_failed)

#### Stratum1

- `stratum1_ok`: The number of stratum1 servers with status OK (legacy equivalent: `stratum1_servers`)
- `stratum1_degraded`: The number of stratum1 servers with status DEGRADED
- `stratum1_warning`: The number of stratum1 servers with status WARNING
- `stratum1_failed`: The number of stratum1 servers with status FAILED
- `stratum1_total`: The total number of stratum1 servers scraped (should equal stratum1_ok + stratum1_degraded + stratum1_warning + stratum1_failed)

#### Syncservers

- `syncserver_ok`: The number of sync servers with status OK (legacy equivalent: `sync_servers`)
- `syncserver_degraded`: The number of sync servers with status DEGRADED
- `syncserver_warning`: The number of sync servers with status WARNING
- `syncserver_failed`: The number of sync servers with status FAILED
- `syncserver_total`: The total number of sync servers scraped (should equal syncserver_ok + syncserver_degraded + syncserver_warning + syncserver_failed)

Note: It's `syncserver` (no underscore and singular, like stratum0/1).
