### PR TITLE
Add history-backed trends and reliability outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "include_dir",
  "log",
  "once_cell",
+ "reqwest",
  "rhai",
  "serde",
  "serde_json",
@@ -429,6 +430,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "tera",
+ "thiserror",
  "tokio",
  "yare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ tempfile = "3"
 anyhow = "1"
 strum = "0"
 strum_macros = "0"
+reqwest = { version = "0.13", features = ["json"] }
+thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains the source code for an EESSI status page generator. The
 - Scrapes server statuses and generates a static HTML status page.
 - Configurable via a JSON configuration file.
 - Generates both HTML and JSON status reports.
+- Keeps local JSONL history by default and renders history bars and derived reliability metrics.
+- Generates a trends page with optional Grafana/Prometheus disk usage charts.
 - Automatically populates required resources (images, fonts, CSS, JS, templates, etc.) into the destination directory.
 - Supports local editing of resource files, and overwriting them back to the defaults with the `--force` option.
 - Evaluates rules for status conditions using [Rhai](https://rhai.rs).
@@ -42,6 +44,8 @@ Run the binary with the desired options:
 --force-resource-creation, -f: Force overwrite of existing files.
 --output-file, -o: Filename for the generated status page. Default is index.html.
 --json-output-file, -j: Filename for the generated JSON status. Default is status.json.
+--trends-output-file: Filename for the generated trends page. Default is trends.html.
+--trends-json-output-file: Filename for the generated trends JSON. Default is trends.json.
 --prometheus-metrics, -p: Enable Prometheus metrics generation.
 ```
 
@@ -62,6 +66,64 @@ RUST_LOG=info ./cvmfs-status-page-rust -c config.json
 ## Resources
 
 Resources such as images, fonts, CSS, JS, and templates will be populated into the destination directory from the binary if missing. These resources can be edited locally as their existience will prevent recreation. To reinstall the shipped versions, issue the --force option.
+
+## History and Trends
+
+History is enabled by default and stored under `history/` inside the destination directory. Add `"history": { "enabled": false }` to opt out. When enabled, the generator writes `history/snapshots.jsonl`, compact daily rollups, `history.json`, derived uptime/incident fields in `status.json`, and history bars on the status page. Raw samples are retained for 90 days by default.
+
+Generated public outputs include:
+
+- `index.html` by default: the status page, configurable with `--output-file`.
+- `status.json`: the current status payload, configurable with `--json-output-file`.
+- `trends.html`: the trends page, configurable with `--trends-output-file`.
+- `trends.json`: the trends page backing data, configurable with `--trends-json-output-file`.
+- `history.json`: the derived history summary used by the status page when history is enabled.
+- `metrics`: Prometheus-style metrics when `--prometheus-metrics` is enabled.
+
+See [JSON outputs](docs/json-outputs.md) for the generated JSON file formats. See [Prometheus metrics](docs/metrics.md) for the metrics file format.
+
+### Grafana-backed disk usage metrics
+
+Optional Grafana-backed disk usage metrics can be configured with `external_metrics`. The token is read from the environment variable named by `token_env`; tokens are not stored in the JSON config. If the source is configured but unavailable, persisted history samples are used for the chart when available.
+
+Example `external_metrics` block (added at the top level of `config.json`):
+
+```json
+"external_metrics": {
+  "kind": "grafana",
+  "url": "https://grafana.example.org",
+  "datasource_uid": "<prometheus-datasource-uid>",
+  "token_env": "GRAFANA_TOKEN",
+  "timeout_seconds": 10,
+  "stratum1_disk_usage": {
+    "query": "avg(node_filesystem_size_bytes{mountpoint=\"/srv\",instance=~\"{instance_regex}\"}) - avg(node_filesystem_avail_bytes{mountpoint=\"/srv\",instance=~\"{instance_regex}\"})",
+    "range_weeks": 52,
+    "step": "1w",
+    "instance_regex": ".*-s1\\.eessi\\.science(:[0-9]+)?"
+  }
+}
+```
+
+Then export the token before running:
+
+```sh
+export GRAFANA_TOKEN='glsa_...'
+./cvmfs-status-page-rust -d ./output -c ./config.json
+```
+
+Field reference:
+
+- `kind`: must be `"grafana"` (currently the only supported source).
+- `url`: Grafana base URL. Requests are sent to `{url}/api/datasources/proxy/uid/{datasource_uid}/api/v1/query_range` with `Authorization: Bearer $token`.
+- `datasource_uid`: UID of the Prometheus/Mimir datasource inside Grafana (Connections → Data sources → your datasource; the UID is in the URL).
+- `token_env`: name of the environment variable that holds the Grafana API token. The variable name is your choice as long as the exported variable matches.
+- `timeout_seconds`: per-request timeout. Defaults to `10`.
+- `stratum1_disk_usage.query`: PromQL query returning bytes. The literal substring `{instance_regex}` is replaced with `instance_regex` before the query is sent.
+- `stratum1_disk_usage.instance_regex`: regex matching the Stratum 1 `instance` label values to aggregate. Include an optional port suffix if Prometheus stores labels like `host:9100`.
+- `stratum1_disk_usage.range_weeks`: how far back to query. Defaults to `52`.
+- `stratum1_disk_usage.step`: PromQL step. Defaults to `"1w"`.
+
+If the token env var is missing or empty, or Grafana is unreachable, the trends page falls back to persisted history samples.
 
 ## Server Backend Types
 
@@ -171,106 +233,4 @@ In this example, as the rules are applied in order, the engine will check, in or
 Prometheus metrics can be enabled with the `--prometheus-metrics` option. The metrics are exposed as the file `metrics` in the
 output directory and are generated with the timestamp being the start of the application.
 
-The status codes used in the metrics are as follows:
-
-- `0`: OK
-- `1`: Degraded
-- `2`: Warning
-- `3`: Failed
-- `9`: Maintenance
-
-A typical metrics file might look like this:
-
-```prometheus
-# HELP eessi_status EESSI status
-# TYPE eessi_status gauge
-eessi_status 2 1720525887957
-# HELP stratum0_status Stratum0 status
-# TYPE stratum0_status gauge
-stratum0_status 3 1720525887957
-# HELP stratum1_status Stratum1 status
-# TYPE stratum1_status gauge
-stratum1_status 0 1720525887957
-# HELP syncservers_status SyncServers status
-# TYPE syncservers_status gauge
-syncservers_status 0 1720525887957
-# HELP repositories_status Repositories status
-# TYPE repositories_status gauge
-repositories_status 0 1720525887957
-# HELP status_overview Status overview
-# TYPE status_overview gauge
-status_overview{category="overall"} 0 1761206997670
-status_overview{category="stratum0"} 0 1761206997670
-status_overview{category="stratum1"} 0 1761206997670
-status_overview{category="syncservers"} 0 1761206997670
-status_overview{category="repositories"} 0 1761206997670
-# HELP repo_catalogue_size Repository catalogue size
-# TYPE repo_catalogue_size gauge
-repo_catalogue_size{type="stratum0",server="rug-nl-s0.eessi.science",repository="dev.eessi.io"} 9526272 1761206997670
-repo_catalogue_size{type="stratum0",server="rug-nl-s0.eessi.science",repository="riscv.eessi.io"} 26624 1761206997670
-repo_catalogue_size{type="stratum0",server="rug-nl-s0.eessi.science",repository="software.eessi.io"} 133120 1761206997670
-repo_catalogue_size{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="dev.eessi.io"} 9526272 1761206997670
-repo_catalogue_size{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="riscv.eessi.io"} 26624 1761206997670
-repo_catalogue_size{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 133120 1761206997670
-repo_catalogue_size{type="stratum1",server="azure-us-east-s1.eessi.science",repository="dev.eessi.io"} 9526272 1761206997670
-repo_catalogue_size{type="stratum1",server="azure-us-east-s1.eessi.science",repository="riscv.eessi.io"} 26624 1761206997670
-repo_catalogue_size{type="stratum1",server="azure-us-east-s1.eessi.science",repository="software.eessi.io"} 133120 1761206997670
-repo_catalogue_size{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="dev.eessi.io"} 9526272 1761206997670
-repo_catalogue_size{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="riscv.eessi.io"} 26624 1761206997670
-repo_catalogue_size{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="software.eessi.io"} 133120 1761206997670
-repo_catalogue_size{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="dev.eessi.io"} 9526272 1761206997670
-repo_catalogue_size{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="riscv.eessi.io"} 26624 1761206997670
-repo_catalogue_size{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="software.eessi.io"} 133120 1761206997670
-# HELP repo_revision Repository revision
-# TYPE repo_revision gauge
-repo_revision{type="stratum0",server="rug-nl-s0.eessi.science",repository="dev.eessi.io"} 415 1761206997670
-repo_revision{type="stratum0",server="rug-nl-s0.eessi.science",repository="riscv.eessi.io"} 522 1761206997670
-repo_revision{type="stratum0",server="rug-nl-s0.eessi.science",repository="software.eessi.io"} 9744 1761206997670
-repo_revision{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="dev.eessi.io"} 415 1761206997670
-repo_revision{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="riscv.eessi.io"} 522 1761206997670
-repo_revision{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 9744 1761206997670
-repo_revision{type="stratum1",server="azure-us-east-s1.eessi.science",repository="dev.eessi.io"} 415 1761206997670
-repo_revision{type="stratum1",server="azure-us-east-s1.eessi.science",repository="riscv.eessi.io"} 522 1761206997670
-repo_revision{type="stratum1",server="azure-us-east-s1.eessi.science",repository="software.eessi.io"} 9744 1761206997670
-repo_revision{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="dev.eessi.io"} 415 1761206997670
-repo_revision{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="riscv.eessi.io"} 522 1761206997670
-repo_revision{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="software.eessi.io"} 9744 1761206997670
-repo_revision{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="dev.eessi.io"} 415 1761206997670
-repo_revision{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="riscv.eessi.io"} 522 1761206997670
-repo_revision{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="software.eessi.io"} 9744 1761206997670
-# HELP repo_timestamp Repository timestamp
-# TYPE repo_timestamp gauge
-repo_timestamp{type="stratum0",server="rug-nl-s0.eessi.science",repository="dev.eessi.io"} 1760706941 1761206997670
-repo_timestamp{type="stratum0",server="rug-nl-s0.eessi.science",repository="riscv.eessi.io"} 1750670430 1761206997670
-repo_timestamp{type="stratum0",server="rug-nl-s0.eessi.science",repository="software.eessi.io"} 1761150935 1761206997670
-repo_timestamp{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="dev.eessi.io"} 1760706941 1761206997670
-repo_timestamp{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="riscv.eessi.io"} 1750670430 1761206997670
-repo_timestamp{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 1761150935 1761206997670
-repo_timestamp{type="stratum1",server="azure-us-east-s1.eessi.science",repository="dev.eessi.io"} 1760706941 1761206997670
-repo_timestamp{type="stratum1",server="azure-us-east-s1.eessi.science",repository="riscv.eessi.io"} 1750670430 1761206997670
-repo_timestamp{type="stratum1",server="azure-us-east-s1.eessi.science",repository="software.eessi.io"} 1761150935 1761206997670
-repo_timestamp{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="dev.eessi.io"} 1760706941 1761206997670
-repo_timestamp{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="riscv.eessi.io"} 1750670430 1761206997670
-repo_timestamp{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="software.eessi.io"} 1761150935 1761206997670
-repo_timestamp{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="dev.eessi.io"} 1760706941 1761206997670
-repo_timestamp{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="riscv.eessi.io"} 1750670430 1761206997670
-repo_timestamp{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="software.eessi.io"} 1761150935 1761206997670
-# HELP repo_ttl Repository TTL
-# TYPE repo_ttl gauge
-repo_ttl{type="stratum0",server="rug-nl-s0.eessi.science",repository="dev.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum0",server="rug-nl-s0.eessi.science",repository="riscv.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum0",server="rug-nl-s0.eessi.science",repository="software.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="dev.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="riscv.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="azure-us-east-s1.eessi.science",repository="dev.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="azure-us-east-s1.eessi.science",repository="riscv.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="azure-us-east-s1.eessi.science",repository="software.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="dev.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="riscv.eessi.io"} 240 1761206997670
-repo_ttl{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000",repository="software.eessi.io"} 240 1761206997670
-repo_ttl{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="dev.eessi.io"} 240 1761206997670
-repo_ttl{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="riscv.eessi.io"} 240 1761206997670
-repo_ttl{type="syncserver",server="aws-eu-west-s1-sync.eessi.science",repository="software.eessi.io"} 240 1761206997670
-
-```
+See [Prometheus metrics](docs/metrics.md) for the metric families, labels, status code values, and examples.

--- a/config.json
+++ b/config.json
@@ -36,6 +36,13 @@
     "ignored_repositories": [
         "test.eessi.io"
     ],
+    "history": {
+        "enabled": true,
+        "directory": "history",
+        "retention_days_raw": 90,
+        "retention_days_daily": 90,
+        "bucket_window_days": 90
+    },
     "rules": [
         {
             "id": "stratum1_servers",

--- a/docs/json-outputs.md
+++ b/docs/json-outputs.md
@@ -1,0 +1,68 @@
+# JSON Outputs
+
+The generator writes public JSON outputs next to the generated HTML files. These files are intended for consumers that want the current status, derived history, or trends data without parsing HTML.
+
+## `status.json`
+
+`status.json` is the main current status payload. Its filename is configurable with `--json-output-file`.
+
+Top-level fields include:
+
+- `title`, `contact_email`, and `last_update`.
+- `eessi_status`, `stratum0`, `stratum1`, `syncservers`, and `repositories_status`.
+- `repositories` and `servers` for the current scraped status tables.
+- `summary` with current counts and aggregate values.
+- `repositories_enriched` and `servers_enriched` with normalized status data for richer clients.
+- `trends_url` and `history_url` for linking to related generated outputs.
+- `history_meta` when history is enabled and loaded successfully.
+- `config`, which contains the effective configuration used for the run.
+
+When history is available, each enriched server can include `uptime` and `incidents_90d`.
+
+## `history.json`
+
+`history.json` is the public derived history summary. It is written when history is enabled and history processing succeeds. The filename is fixed.
+
+Top-level fields:
+
+- `v`: schema version for this public history payload.
+- `generated_at`: Unix timestamp in seconds.
+- `bucket_window_days`: number of days represented by the history bars.
+- `servers`: object keyed by hostname.
+- `repositories`: object keyed by repository name.
+
+Each server entry contains:
+
+- `server_type`: `stratum0`, `stratum1`, or `syncserver`.
+- `uptime`: 30-day and 90-day uptime fractions, observed sample counts, last OK/failure timestamps when known, longest outage, and MTTR when incidents exist.
+- `bars`: daily status bars with date `d`, status `s`, optional `ok_fraction`, and transition count.
+- `incidents_90d`: incidents with start, optional end, duration, and status.
+
+Each repository entry contains:
+
+- `sync_lag_p50_30d`, `sync_lag_p95_30d`, and `sync_lag_max_30d` when lag samples exist.
+- `revisions_per_week_30d` when enough revision samples exist.
+- `revision_series`, an array of `{ "t": <unix seconds>, "r": <revision> }` points.
+
+Internal persisted history files are separate from this public summary. `history/snapshots.jsonl` stores raw samples, and `history/daily/*.json` stores compact daily rollups used as inputs for future runs.
+
+## `trends.json`
+
+`trends.json` is the backing payload for the generated trends page. Its filename is configurable with `--trends-json-output-file`.
+
+Top-level fields:
+
+- `v`: schema version for the trends payload.
+- `generated_at`: Unix timestamp in seconds.
+- `back_url`, `status_json_url`, `trends_json_url`, and `asset_base_url` for page navigation and asset loading.
+- `title` and `contact_email`.
+- `external_metrics_configured`: whether `external_metrics` was configured.
+- `external_metrics`: optional external metrics data, currently Grafana-backed Stratum 1 disk usage.
+
+When present, `external_metrics` contains:
+
+- `source`: currently `grafana`.
+- `fetched_at`: Unix timestamp in seconds for the live external fetch, when available.
+- `sampled_at`: timestamp of the latest disk usage sample, when available.
+- `fallback_from_history`: true when persisted history samples were used because live external metrics were unavailable.
+- `stratum1_disk_usage`: bytes-based current value, 52-week maximum, human-readable values, and a timestamped byte series.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,84 @@
+# Prometheus Metrics
+
+Prometheus metrics are generated when the binary is run with `--prometheus-metrics`. The output file is named `metrics` and is written to the destination directory. Every sample uses the run start time as its Prometheus timestamp in milliseconds.
+
+## Status Codes
+
+- `0`: OK
+- `1`: Degraded
+- `2`: Warning
+- `3`: Failed
+- `9`: Maintenance
+
+## Metric Families
+
+Most metrics describe the current scrape and do not require history. Only the derived server reliability metrics and derived repository trend metrics depend on history.
+
+Current status gauges:
+
+- `eessi_status`: overall EESSI status.
+- `stratum0_status`: aggregate Stratum 0 status.
+- `stratum1_status`: aggregate Stratum 1 status.
+- `syncservers_status`: aggregate sync server status.
+- `repositories_status`: aggregate repository status.
+- `status_overview{category}`: same status values grouped by `category`; categories are `overall`, `stratum0`, `stratum1`, `syncservers`, and `repositories`.
+
+Repository manifest gauges are emitted for each scraped repository on each scraped server. They use labels `type`, `server`, and `repository`.
+
+- `repo_revision`: repository revision number.
+- `repo_timestamp`: repository manifest timestamp in Unix seconds.
+- `repo_ttl`: repository TTL in seconds.
+- `repo_catalogue_size`: root catalogue size in bytes.
+
+Derived server reliability gauges are emitted only when history is enabled and derived history data loads successfully for the run. They use labels `type` and `server`.
+
+- `server_uptime_pct_30d`: fraction of observed samples that were serving successfully in the last 30 days.
+- `server_uptime_pct_90d`: fraction of observed samples that were serving successfully in the last 90 days.
+- `server_longest_outage_seconds_90d`: longest observed outage duration in the last 90 days.
+- `server_mttr_seconds_90d`: mean time to recovery in seconds for incidents in the last 90 days. This individual metric is omitted for servers with no incidents.
+
+Derived repository trend gauges are emitted only when history is enabled and derived history data loads successfully for the run. They use the `repository` label. Individual metrics are omitted when the required lag or revision samples are not available.
+
+- `repo_sync_lag_seconds_p50_30d`: p50 Stratum 1 sync lag against Stratum 0 in the last 30 days.
+- `repo_sync_lag_seconds_p95_30d`: p95 Stratum 1 sync lag against Stratum 0 in the last 30 days.
+- `repo_sync_lag_seconds_max_30d`: maximum Stratum 1 sync lag against Stratum 0 in the last 30 days.
+- `repo_revisions_per_week_30d`: observed repository revision rate over the last 30 days.
+
+## Example
+
+```prometheus
+# HELP eessi_status EESSI status
+# TYPE eessi_status gauge
+eessi_status 0 1781513401930
+# HELP repositories_status Repositories status
+# TYPE repositories_status gauge
+repositories_status 0 1781513401930
+# HELP status_overview Status overview
+# TYPE status_overview gauge
+status_overview{category="overall"} 0 1781513401930
+status_overview{category="repositories"} 0 1781513401930
+# HELP repo_revision Repository revision
+# TYPE repo_revision gauge
+repo_revision{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 9744 1781513401930
+# HELP repo_timestamp Repository timestamp
+# TYPE repo_timestamp gauge
+repo_timestamp{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 1761150935 1781513401930
+# HELP repo_ttl Repository TTL
+# TYPE repo_ttl gauge
+repo_ttl{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 240 1781513401930
+# HELP repo_catalogue_size Repository catalogue size
+# TYPE repo_catalogue_size gauge
+repo_catalogue_size{type="stratum1",server="aws-eu-central-s1.eessi.science",repository="software.eessi.io"} 133120 1781513401930
+# HELP server_uptime_pct_30d Server uptime percentage over observed samples in 30 days
+# TYPE server_uptime_pct_30d gauge
+server_uptime_pct_30d{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000"} 0.9957081545064378 1781513401930
+# HELP server_longest_outage_seconds_90d Server longest outage seconds in 90 days
+# TYPE server_longest_outage_seconds_90d gauge
+server_longest_outage_seconds_90d{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000"} 540 1781513401930
+# HELP server_mttr_seconds_90d Server mean time to recovery seconds in 90 days
+# TYPE server_mttr_seconds_90d gauge
+server_mttr_seconds_90d{type="stratum1",server="cvmfs-ext.gridpp.rl.ac.uk:8000"} 540 1781513401930
+# HELP repo_sync_lag_seconds_p95_30d Repository sync lag p95 seconds in 30 days
+# TYPE repo_sync_lag_seconds_p95_30d gauge
+repo_sync_lag_seconds_p95_30d{repository="software.eessi.io"} 120 1781513401930
+```

--- a/resources/status.css
+++ b/resources/status.css
@@ -169,7 +169,7 @@ ul.details {
     border: 1px solid #fff;
 }
 
-.infobox:hover {
+.infobox:not(.trends-section):hover {
     border: 1px solid var(--color-step-500);
     background-color: #ddd;
     cursor: pointer;
@@ -299,6 +299,102 @@ th.geoapi {
     text-align: center;
 }
 
+.site-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.site-header h1 {
+    flex: 1;
+}
+
+.site-header .logo {
+    margin-left: 1rem;
+}
+
+.muted {
+    color: var(--color-text-desc);
+}
+
+.history-panel,
+.trends-section {
+    background-color: var(--color-content-bar);
+    -webkit-box-shadow: 2px 2px 7px -4px #000000;
+    box-shadow: 2px 2px 7px -4px #000000;
+    padding: 1em;
+    margin-bottom: 2em;
+    border-radius: 8px;
+}
+
+.trends-section {
+    cursor: default;
+}
+
+.history-panel {
+    clear: both;
+}
+
+.history-panel h2,
+.trends-section h2 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    padding-top: 0;
+}
+
+.history-server {
+    margin: 1rem 0;
+}
+
+.history-title,
+.chart-summary {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    color: var(--color-text);
+}
+
+.history-svg {
+    display: block;
+    width: 100%;
+    height: 26px;
+    margin-top: 0.35rem;
+}
+
+.status-ok-fill {
+    fill: var(--color-success);
+}
+
+.status-degraded-fill {
+    fill: var(--color-info);
+}
+
+.status-warning-fill {
+    fill: var(--color-warning);
+}
+
+.status-failed-fill {
+    fill: var(--color-danger);
+}
+
+.status-maintenance-fill {
+    fill: var(--color-maintenance);
+}
+
+.status-nodata-fill {
+    fill: var(--color-step-400);
+}
+
+.trends-chart {
+    width: 100%;
+    height: 100%;
+}
+
+.chart-canvas-wrap {
+    height: 320px;
+    margin-top: 0.5rem;
+}
+
 td.main {
     text-align: left;
 }
@@ -316,6 +412,12 @@ th {
     color: var(--color-step-700);
     font-size: 0.7em;
     font-weight: 300;
+}
+
+.footer a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
 }
 
 .color-green,

--- a/resources/status.js
+++ b/resources/status.js
@@ -24,12 +24,74 @@ function open_syncservers() {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  document.getElementById('stratum0_handler')
-    .addEventListener('click', open_stratum0);
-  document.getElementById('stratum1_handler')
-    .addEventListener('click', open_stratum1);
-  document.getElementById('repositories_handler')
-    .addEventListener('click', open_repositories);
-  document.getElementById('syncservers_handler')
-    .addEventListener('click', open_syncservers);
+  addClickHandler('stratum0_handler', open_stratum0);
+  addClickHandler('stratum1_handler', open_stratum1);
+  addClickHandler('repositories_handler', open_repositories);
+  addClickHandler('syncservers_handler', open_syncservers);
+  renderHistoryBars();
 });
+
+function addClickHandler(id, handler) {
+  var el = document.getElementById(id);
+  if (el) el.addEventListener('click', handler);
+}
+
+function renderHistoryBars() {
+  var holder = document.getElementById('history-bars');
+  if (!holder) return;
+  var url = holder.getAttribute('data-history-url') || window.STATUS_HISTORY_URL || 'history.json';
+  fetch(url)
+    .then(function (r) {
+      if (!r.ok) throw new Error('history unavailable');
+      return r.json();
+    })
+    .then(function (history) {
+      var servers = history.servers || {};
+      var names = Object.keys(servers).sort();
+      if (names.length === 0) {
+        holder.innerHTML = '<p class="muted">No history yet.</p>';
+        return;
+      }
+      holder.innerHTML = names.map(function (name) {
+        var server = servers[name];
+        var pct = server.uptime ? (server.uptime.pct_90d * 100).toFixed(1) : '0.0';
+        return '<div class="history-server"><div class="history-title"><span>' +
+          escapeHtml(name) + '</span><span>' + pct + '% · 90d</span></div>' +
+          barsSvg(server.bars || []) + '</div>';
+      }).join('');
+    })
+    .catch(function () {
+      holder.innerHTML = '<p class="muted">History unavailable.</p>';
+    });
+}
+
+function barsSvg(bars) {
+  var width = 720;
+  var height = 24;
+  var gap = 1;
+  var barWidth = Math.max(2, Math.floor((width - gap * Math.max(0, bars.length - 1)) / Math.max(1, bars.length)));
+  var rects = bars.map(function (bar, idx) {
+    var cls = 'history-bar ' + statusClass(bar.s);
+    var x = idx * (barWidth + gap);
+    var title = escapeHtml(bar.d + ' · ' + bar.s + ' · transitions ' + bar.transitions);
+    return '<rect class="' + cls + '" x="' + x + '" y="2" width="' + barWidth + '" height="20" rx="1"><title>' + title + '</title></rect>';
+  }).join('');
+  return '<svg class="history-svg" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none">' + rects + '</svg>';
+}
+
+function statusClass(status) {
+  switch (status) {
+    case 'OK': return 'status-ok-fill';
+    case 'DEGRADED': return 'status-degraded-fill';
+    case 'WARNING': return 'status-warning-fill';
+    case 'FAILED': return 'status-failed-fill';
+    case 'MAINTENANCE': return 'status-maintenance-fill';
+    default: return 'status-nodata-fill';
+  }
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, function (ch) {
+    return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' })[ch];
+  });
+}

--- a/resources/trends.js
+++ b/resources/trends.js
@@ -1,0 +1,132 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var holder = document.getElementById('disk-usage-chart');
+  if (!holder) return;
+  var url = holder.getAttribute('data-trends-json-url') || window.TRENDS_JSON_URL || 'trends.json';
+  fetch(url)
+    .then(function (r) {
+      if (!r.ok) throw new Error('trends unavailable');
+      return r.json();
+    })
+    .then(function (data) {
+      var metric = data.external_metrics && data.external_metrics.stratum1_disk_usage;
+      if (!metric) {
+        holder.innerHTML = '<p class="muted">Disk usage unavailable.</p>';
+        return;
+      }
+      renderChart(holder, metric, data.external_metrics.fallback_from_history);
+    })
+    .catch(function () {
+      holder.innerHTML = '<p class="muted">Disk usage unavailable.</p>';
+    });
+});
+
+function renderChart(holder, metric, fallback) {
+  var series = metric.series || [];
+  if (series.length === 0) {
+    holder.innerHTML = '<p class="muted">No disk usage samples.</p>';
+    return;
+  }
+  if (!window.Chart) {
+    holder.innerHTML = '<p class="muted">Chart library unavailable.</p>';
+    return;
+  }
+
+  var chartId = 'disk-usage-canvas';
+  holder.innerHTML =
+    '<div class="chart-summary"><strong>' + escapeHtml(metric.current_human) + '</strong><span>52w max ' + escapeHtml(metric.max_human_52w) + '</span></div>' +
+    '<div class="chart-canvas-wrap"><canvas id="' + chartId + '"></canvas></div>';
+
+  var historical = series.map(function (point) {
+    return { x: point.t * 1000, y: point.bytes };
+  });
+  var minX = historical[0].x;
+  var maxX = historical[historical.length - 1].x;
+  var datasets = [{
+    label: 'Used disk space',
+    data: historical,
+    borderColor: '#4e79a7',
+    backgroundColor: 'rgba(78, 121, 167, 0.12)',
+    pointBackgroundColor: '#4e79a7',
+    pointBorderColor: '#ffffff',
+    pointRadius: 2.5,
+    pointHoverRadius: 5,
+    borderWidth: 2,
+    tension: 0.25,
+    fill: true
+  }];
+
+  var ctx = document.getElementById(chartId).getContext('2d');
+  var chart = new Chart(ctx, {
+    type: 'line',
+    data: { datasets: datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'nearest', intersect: false },
+      plugins: {
+        legend: {
+          labels: { usePointStyle: true, boxWidth: 8 }
+        },
+        tooltip: {
+          callbacks: {
+            title: function (items) {
+              if (!items.length) return '';
+              return formatDate(items[0].parsed.x);
+            },
+            label: function (item) {
+              return item.dataset.label + ': ' + formatBytes(item.parsed.y);
+            }
+          }
+        }
+      },
+      scales: {
+        x: {
+          type: 'linear',
+          min: minX,
+          max: maxX,
+          offset: false,
+          bounds: 'data',
+          ticks: {
+            maxTicksLimit: 10,
+            callback: function (value) { return formatShortDate(value); }
+          },
+          grid: { color: 'rgba(180, 187, 196, 0.35)' }
+        },
+        y: {
+          ticks: {
+            callback: function (value) { return formatTb(value); }
+          },
+          grid: { color: 'rgba(180, 187, 196, 0.35)' },
+          title: { display: true, text: 'Used disk space' }
+        }
+      }
+    }
+  });
+
+}
+
+function formatBytes(bytes) {
+  var tb = 1000000000000;
+  var gb = 1000000000;
+  if (bytes >= tb) return (bytes / tb).toFixed(2) + ' TB';
+  if (bytes >= gb) return (bytes / gb).toFixed(1) + ' GB';
+  return Math.round(bytes) + ' B';
+}
+
+function formatTb(bytes) {
+  return (bytes / 1000000000000).toFixed(1) + ' TB';
+}
+
+function formatDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function formatShortDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, function (ch) {
+    return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' })[ch];
+  });
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
+use std::path::PathBuf;
 use std::sync::RwLock;
 
 use crate::models::Status;
@@ -26,6 +27,38 @@ fn scrape_only_explicit_repositories() -> bool {
     false
 }
 
+fn default_history_enabled() -> bool {
+    true
+}
+
+fn default_history_directory() -> PathBuf {
+    PathBuf::from("history")
+}
+
+fn default_retention_days_raw() -> u32 {
+    90
+}
+
+fn default_retention_days_daily() -> u32 {
+    90
+}
+
+fn default_bucket_window_days() -> u32 {
+    90
+}
+
+fn default_timeout_seconds() -> u64 {
+    10
+}
+
+fn default_range_weeks() -> u32 {
+    52
+}
+
+fn default_step() -> String {
+    "1w".to_string()
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ConfigFile {
     pub meta: ConfigSection,
@@ -35,6 +68,62 @@ pub struct ConfigFile {
     pub limit_scraping_to_repositories: bool,
     pub ignored_repositories: Vec<String>,
     pub rules: Vec<Rule>,
+    #[serde(default)]
+    pub history: HistorySection,
+    #[serde(default)]
+    pub external_metrics: Option<ExternalMetricsConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct HistorySection {
+    #[serde(default = "default_history_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_history_directory")]
+    pub directory: PathBuf,
+    #[serde(default = "default_retention_days_raw")]
+    pub retention_days_raw: u32,
+    #[serde(default = "default_retention_days_daily")]
+    pub retention_days_daily: u32,
+    #[serde(default = "default_bucket_window_days")]
+    pub bucket_window_days: u32,
+}
+
+impl Default for HistorySection {
+    fn default() -> Self {
+        Self {
+            enabled: default_history_enabled(),
+            directory: default_history_directory(),
+            retention_days_raw: default_retention_days_raw(),
+            retention_days_daily: default_retention_days_daily(),
+            bucket_window_days: default_bucket_window_days(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ExternalMetricsConfig {
+    Grafana(GrafanaMetricsConfig),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct GrafanaMetricsConfig {
+    pub url: String,
+    pub datasource_uid: String,
+    pub token_env: String,
+    #[serde(default = "default_timeout_seconds")]
+    pub timeout_seconds: u64,
+    pub stratum1_disk_usage: Stratum1DiskUsageConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Stratum1DiskUsageConfig {
+    pub query: String,
+    #[serde(default = "default_range_weeks")]
+    pub range_weeks: u32,
+    #[serde(default = "default_step")]
+    pub step: String,
+    pub instance_regex: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -149,6 +238,8 @@ mod tests {
             ignored_repositories: vec![],
             rules: vec![],
             limit_scraping_to_repositories: false,
+            history: HistorySection::default(),
+            external_metrics: None,
         };
 
         let manager = ConfigManager {
@@ -186,6 +277,8 @@ mod tests {
             ignored_repositories: vec![],
             rules: vec![],
             limit_scraping_to_repositories: false,
+            history: HistorySection::default(),
+            external_metrics: None,
         };
 
         let manager = ConfigManager {

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -10,6 +10,9 @@ use tempfile::NamedTempFile;
 
 const RESOURCES_DIR: Dir = include_dir!("resources");
 const STATUS_TEMPLATE: &str = include_str!("../templates/status.html");
+const TRENDS_TEMPLATE: &str = include_str!("../templates/trends.html");
+const HEADER_TEMPLATE: &str = include_str!("../templates/_header.html");
+const FOOTER_TEMPLATE: &str = include_str!("../templates/_footer.html");
 
 pub struct Stats {
     files_checked: AtomicUsize,
@@ -39,7 +42,10 @@ pub fn populate(path: &str, force: bool) -> Result<()> {
 
     populate_dirs_and_files(&RESOURCES_DIR, output_dir, force)?;
     populate_root_files(output_dir, force)?;
-    create_status_template(output_dir, force)?;
+    create_template(output_dir, force, "status.html", STATUS_TEMPLATE)?;
+    create_template(output_dir, force, "trends.html", TRENDS_TEMPLATE)?;
+    create_template(output_dir, force, "_header.html", HEADER_TEMPLATE)?;
+    create_template(output_dir, force, "_footer.html", FOOTER_TEMPLATE)?;
 
     debug!(
         "Population of resource files complete. Files checked: {}, written: {}, skipped: {}",
@@ -105,21 +111,19 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn create_status_template(output_dir: &Path, force: bool) -> Result<()> {
-    let template_path = output_dir.join("templates").join("status.html");
+fn create_template(output_dir: &Path, force: bool, name: &str, contents: &str) -> Result<()> {
+    let template_path = output_dir.join("templates").join(name);
     STATS.files_checked.fetch_add(1, Ordering::Relaxed);
-    trace!("Checking status template: {:?}", template_path);
+    trace!("Checking template: {:?}", template_path);
     if should_skip_file(&template_path, force) {
         STATS.files_skipped.fetch_add(1, Ordering::Relaxed);
-        trace!("Skipping existing status template");
+        trace!("Skipping existing template");
         return Ok(());
     }
-    trace!("Creating status template: {:?}", template_path);
+    trace!("Creating template: {:?}", template_path);
     ensure_parent_dir(&template_path)?;
-    atomic_write(&template_path, STATUS_TEMPLATE.as_bytes()).context(format!(
-        "Failed to create status template: {:?}",
-        template_path
-    ))?;
+    atomic_write(&template_path, contents.as_bytes())
+        .context(format!("Failed to create template: {:?}", template_path))?;
     STATS.files_written.fetch_add(1, Ordering::Relaxed);
     Ok(())
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -1,0 +1,562 @@
+use chrono::{Duration, NaiveDate, TimeZone, Utc};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::history::{HistoryView, Snapshot, SnapshotServer};
+use crate::models::{
+    HistoryBar, HistoryJson, HistoryRepoJson, HistoryServerJson, Incident, RevisionPoint,
+    ServerUptime, Status,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct DerivedMetrics {
+    pub servers: BTreeMap<String, ServerDerived>,
+    pub repositories: BTreeMap<String, RepoDerived>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ServerDerived {
+    pub server_type: String,
+    pub uptime: ServerUptime,
+    pub incidents_90d: Vec<Incident>,
+    pub bars: Vec<HistoryBar>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RepoDerived {
+    pub sync_lag_p50_30d: Option<i64>,
+    pub sync_lag_p95_30d: Option<i64>,
+    pub sync_lag_max_30d: Option<i64>,
+    pub revisions_per_week_30d: Option<f64>,
+    pub revision_series: Vec<RevisionPoint>,
+}
+
+pub fn derive(
+    view: &HistoryView,
+    now: chrono::DateTime<Utc>,
+    bucket_window_days: u32,
+    expected_repositories: &[String],
+) -> DerivedMetrics {
+    let mut out = DerivedMetrics::default();
+    let cutoff_90 = (now - Duration::days(90)).timestamp();
+    let cutoff_30 = (now - Duration::days(30)).timestamp();
+    let expected_repositories = expected_repositories.iter().collect::<BTreeSet<_>>();
+
+    let mut server_names = BTreeMap::<String, String>::new();
+    for snap in &view.raw {
+        for (host, server) in &snap.servers {
+            server_names.insert(host.clone(), server.server_type.clone());
+        }
+    }
+    for daily in &view.daily {
+        for (host, server) in &daily.servers {
+            server_names.insert(host.clone(), server.server_type.clone());
+        }
+    }
+
+    for (host, server_type) in server_names {
+        let uptime = server_uptime(&host, view, cutoff_30, cutoff_90, &expected_repositories);
+        let incidents_90d = incidents_for_server(
+            &host,
+            &view.raw,
+            cutoff_90,
+            now.timestamp(),
+            &expected_repositories,
+        );
+        let bars = bars_for_server(
+            &host,
+            view,
+            now.date_naive(),
+            bucket_window_days,
+            &expected_repositories,
+        );
+        out.servers.insert(
+            host,
+            ServerDerived {
+                server_type,
+                uptime,
+                incidents_90d,
+                bars,
+            },
+        );
+    }
+
+    for (repo, derived) in derive_repositories(view, cutoff_30) {
+        out.repositories.insert(repo, derived);
+    }
+
+    out
+}
+
+pub fn build_history_json(
+    derived: &DerivedMetrics,
+    now: chrono::DateTime<Utc>,
+    bucket_window_days: u32,
+) -> HistoryJson {
+    HistoryJson {
+        v: 1,
+        generated_at: now.timestamp(),
+        bucket_window_days,
+        servers: derived
+            .servers
+            .iter()
+            .map(|(host, d)| {
+                (
+                    host.clone(),
+                    HistoryServerJson {
+                        server_type: d.server_type.clone(),
+                        uptime: d.uptime.clone(),
+                        bars: d.bars.clone(),
+                        incidents_90d: d.incidents_90d.clone(),
+                    },
+                )
+            })
+            .collect(),
+        repositories: derived
+            .repositories
+            .iter()
+            .map(|(repo, d)| {
+                (
+                    repo.clone(),
+                    HistoryRepoJson {
+                        sync_lag_p50_30d: d.sync_lag_p50_30d,
+                        sync_lag_p95_30d: d.sync_lag_p95_30d,
+                        sync_lag_max_30d: d.sync_lag_max_30d,
+                        revisions_per_week_30d: d.revisions_per_week_30d,
+                        revision_series: d.revision_series.clone(),
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+fn server_uptime(
+    host: &str,
+    view: &HistoryView,
+    cutoff_30: i64,
+    cutoff_90: i64,
+    expected_repositories: &BTreeSet<&String>,
+) -> ServerUptime {
+    let mut observed_30 = 0usize;
+    let mut ok_30 = 0usize;
+    let mut observed_90 = 0usize;
+    let mut ok_90 = 0usize;
+    let mut last_ok_at = None;
+    let mut last_failure_at = None;
+
+    for snap in &view.raw {
+        if let Some(server) = snap.servers.get(host) {
+            let status = serving_status(server, expected_repositories);
+            if snap.t >= cutoff_90 {
+                observed_90 += 1;
+                if status == Status::OK {
+                    ok_90 += 1;
+                    last_ok_at = Some(snap.t);
+                } else {
+                    last_failure_at = Some(snap.t);
+                }
+            }
+            if snap.t >= cutoff_30 {
+                observed_30 += 1;
+                if status == Status::OK {
+                    ok_30 += 1;
+                }
+            }
+        }
+    }
+
+    for daily in &view.daily {
+        if let Some(day_ts) = day_start_ts(&daily.date) {
+            if day_ts >= cutoff_90 {
+                if let Some(server) = daily.servers.get(host) {
+                    observed_90 += server.observed;
+                    ok_90 += server.ok_count;
+                    if day_ts >= cutoff_30 {
+                        observed_30 += server.observed;
+                        ok_30 += server.ok_count;
+                    }
+                }
+            }
+        }
+    }
+
+    let incidents = incidents_for_server(
+        host,
+        &view.raw,
+        cutoff_90,
+        Utc::now().timestamp(),
+        expected_repositories,
+    );
+    let longest = incidents
+        .iter()
+        .map(|i| i.duration_seconds)
+        .max()
+        .unwrap_or(0);
+    let mttr_seconds_90d = if incidents.is_empty() {
+        None
+    } else {
+        Some(incidents.iter().map(|i| i.duration_seconds).sum::<i64>() / incidents.len() as i64)
+    };
+
+    ServerUptime {
+        pct_30d: fraction(ok_30, observed_30),
+        pct_90d: fraction(ok_90, observed_90),
+        observed_samples_30d: observed_30,
+        observed_samples_90d: observed_90,
+        last_ok_at,
+        last_failure_at,
+        longest_outage_seconds_90d: longest,
+        mttr_seconds_90d,
+    }
+}
+
+fn incidents_for_server(
+    host: &str,
+    raw: &[Snapshot],
+    cutoff: i64,
+    now_ts: i64,
+    expected_repositories: &BTreeSet<&String>,
+) -> Vec<Incident> {
+    let mut snaps = raw
+        .iter()
+        .filter(|s| s.t >= cutoff)
+        .filter_map(|s| {
+            s.servers
+                .get(host)
+                .map(|server| (s.t, serving_status(server, expected_repositories)))
+        })
+        .collect::<Vec<_>>();
+    snaps.sort_by_key(|(t, _)| *t);
+
+    let mut incidents = Vec::new();
+    let mut current: Option<(i64, Status)> = None;
+    for (t, status) in snaps {
+        match (current, status == Status::OK) {
+            (None, false) => current = Some((t, status)),
+            (Some((start, st)), true) => {
+                incidents.push(Incident {
+                    start,
+                    end: Some(t),
+                    duration_seconds: (t - start).max(0),
+                    status: st,
+                });
+                current = None;
+            }
+            (Some((start, st)), false) => current = Some((start, st.max(status))),
+            (None, true) => {}
+        }
+    }
+    if let Some((start, st)) = current {
+        incidents.push(Incident {
+            start,
+            end: None,
+            duration_seconds: (now_ts - start).max(0),
+            status: st,
+        });
+    }
+    incidents
+}
+
+fn bars_for_server(
+    host: &str,
+    view: &HistoryView,
+    today: NaiveDate,
+    bucket_window_days: u32,
+    expected_repositories: &BTreeSet<&String>,
+) -> Vec<HistoryBar> {
+    let start = today - Duration::days(bucket_window_days.saturating_sub(1) as i64);
+    let mut daily: HashMap<String, HistoryBar> = HashMap::new();
+
+    for rollup in &view.daily {
+        if let Some(server) = rollup.servers.get(host) {
+            daily.insert(
+                rollup.date.clone(),
+                HistoryBar {
+                    d: rollup.date.clone(),
+                    s: server.worst.to_string(),
+                    ok_fraction: Some(server.ok_fraction),
+                    transitions: server.transitions,
+                },
+            );
+        }
+    }
+
+    let mut raw_by_day: HashMap<String, Vec<(i64, Status)>> = HashMap::new();
+    for snap in &view.raw {
+        if let Some(server) = snap.servers.get(host) {
+            if let Some(date) = Utc
+                .timestamp_opt(snap.t, 0)
+                .single()
+                .map(|d| d.date_naive())
+            {
+                raw_by_day
+                    .entry(date.to_string())
+                    .or_default()
+                    .push((snap.t, serving_status(server, expected_repositories)));
+            }
+        }
+    }
+    for (date, mut statuses) in raw_by_day {
+        statuses.sort_by_key(|(t, _)| *t);
+        let observed = statuses.len();
+        let ok = statuses.iter().filter(|(_, s)| *s == Status::OK).count();
+        let transitions = statuses.windows(2).filter(|w| w[0].1 != w[1].1).count();
+        let worst = statuses.iter().map(|(_, s)| *s).max().unwrap_or(Status::OK);
+        daily.insert(
+            date.clone(),
+            HistoryBar {
+                d: date,
+                s: worst.to_string(),
+                ok_fraction: Some(fraction(ok, observed)),
+                transitions,
+            },
+        );
+    }
+
+    (0..bucket_window_days)
+        .map(|idx| {
+            let date = start + Duration::days(idx as i64);
+            daily
+                .remove(&date.to_string())
+                .unwrap_or_else(|| HistoryBar {
+                    d: date.to_string(),
+                    s: "NODATA".to_string(),
+                    ok_fraction: None,
+                    transitions: 0,
+                })
+        })
+        .collect()
+}
+
+fn serving_status(server: &SnapshotServer, expected_repositories: &BTreeSet<&String>) -> Status {
+    if server.s == Status::MAINTENANCE {
+        return Status::MAINTENANCE;
+    }
+    if server.repos.is_empty() {
+        return Status::FAILED;
+    }
+    if expected_repositories.is_empty() {
+        return Status::OK;
+    }
+    if expected_repositories
+        .iter()
+        .all(|repo| server.repos.contains_key(repo.as_str()))
+    {
+        Status::OK
+    } else {
+        Status::FAILED
+    }
+}
+
+fn derive_repositories(view: &HistoryView, cutoff_30: i64) -> BTreeMap<String, RepoDerived> {
+    let mut per_repo_points: BTreeMap<String, Vec<(i64, i32)>> = BTreeMap::new();
+    let mut lag_samples: BTreeMap<String, Vec<i64>> = BTreeMap::new();
+
+    for snap in view.raw.iter().filter(|s| s.t >= cutoff_30) {
+        let stratum0_repos = snap
+            .servers
+            .values()
+            .find(|s| s.server_type == "stratum0")
+            .map(|s| s.repos.clone())
+            .unwrap_or_default();
+        for server in snap.servers.values() {
+            for (repo, data) in &server.repos {
+                per_repo_points
+                    .entry(repo.clone())
+                    .or_default()
+                    .push((snap.t, data.r));
+                if server.server_type == "stratum1" {
+                    if let Some(s0) = stratum0_repos.get(repo) {
+                        lag_samples
+                            .entry(repo.clone())
+                            .or_default()
+                            .push((s0.ts - data.ts).max(0));
+                    }
+                }
+            }
+        }
+    }
+
+    per_repo_points
+        .into_iter()
+        .map(|(repo, mut points)| {
+            points.sort();
+            points.dedup();
+            let first = points.first().copied();
+            let last = points.last().copied();
+            let revisions_per_week_30d = match (first, last) {
+                (Some((t0, r0)), Some((t1, r1))) if t1 > t0 => {
+                    Some(((r1 - r0).max(0) as f64) / ((t1 - t0) as f64 / 604_800.0))
+                }
+                _ => None,
+            };
+            let lags = lag_samples.remove(&repo).unwrap_or_default();
+            let revision_series = points
+                .into_iter()
+                .map(|(t, r)| RevisionPoint { t, r })
+                .collect();
+            (
+                repo,
+                RepoDerived {
+                    sync_lag_p50_30d: percentile(&lags, 0.50),
+                    sync_lag_p95_30d: percentile(&lags, 0.95),
+                    sync_lag_max_30d: lags.iter().max().copied(),
+                    revisions_per_week_30d,
+                    revision_series,
+                },
+            )
+        })
+        .collect()
+}
+
+fn percentile(values: &[i64], p: f64) -> Option<i64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut values = values.to_vec();
+    values.sort();
+    let idx = ((values.len() - 1) as f64 * p).round() as usize;
+    values.get(idx).copied()
+}
+
+fn fraction(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+fn day_start_ts(date: &str) -> Option<i64> {
+    NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .map(|dt| Utc.from_utc_datetime(&dt).timestamp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::{SnapshotRepo, HISTORY_SCHEMA_VERSION};
+
+    fn repo() -> SnapshotRepo {
+        SnapshotRepo { r: 1, ts: 1, cb: 1 }
+    }
+
+    fn server(status: Status, repos: &[&str]) -> SnapshotServer {
+        SnapshotServer {
+            server_type: "stratum1".to_string(),
+            s: status,
+            repos: repos
+                .iter()
+                .map(|name| ((*name).to_string(), repo()))
+                .collect(),
+        }
+    }
+
+    fn snapshot(t: i64, server: SnapshotServer) -> Snapshot {
+        Snapshot {
+            v: HISTORY_SCHEMA_VERSION,
+            t,
+            run_duration_ms: 1,
+            overall: Status::OK,
+            categories: BTreeMap::new(),
+            servers: BTreeMap::from([("s1.example.org".to_string(), server)]),
+            ext: None,
+        }
+    }
+
+    fn derive_one(server: SnapshotServer, expected_repositories: &[String]) -> ServerDerived {
+        let now = Utc.with_ymd_and_hms(2026, 6, 14, 12, 0, 0).unwrap();
+        let snap_time = Utc
+            .with_ymd_and_hms(2026, 6, 13, 12, 0, 0)
+            .unwrap()
+            .timestamp();
+        let view = HistoryView {
+            raw: vec![snapshot(snap_time, server)],
+            daily: Vec::new(),
+        };
+
+        derive(&view, now, 2, expected_repositories)
+            .servers
+            .remove("s1.example.org")
+            .unwrap()
+    }
+
+    #[test]
+    fn serving_server_is_ok_even_when_revision_status_failed() {
+        let expected = vec!["software.eessi.io".to_string(), "dev.eessi.io".to_string()];
+        let derived = derive_one(
+            server(Status::FAILED, &["software.eessi.io", "dev.eessi.io"]),
+            &expected,
+        );
+
+        assert_eq!(derived.uptime.pct_90d, 1.0);
+        assert!(derived.incidents_90d.is_empty());
+        assert_eq!(
+            derived
+                .bars
+                .iter()
+                .find(|bar| bar.d == "2026-06-13")
+                .unwrap()
+                .s,
+            "OK"
+        );
+    }
+
+    #[test]
+    fn missing_expected_repo_is_failed() {
+        let expected = vec!["software.eessi.io".to_string(), "dev.eessi.io".to_string()];
+        let derived = derive_one(server(Status::OK, &["software.eessi.io"]), &expected);
+
+        assert_eq!(derived.uptime.pct_90d, 0.0);
+        assert_eq!(derived.incidents_90d.len(), 1);
+        assert_eq!(derived.incidents_90d[0].status, Status::FAILED);
+        assert_eq!(
+            derived
+                .bars
+                .iter()
+                .find(|bar| bar.d == "2026-06-13")
+                .unwrap()
+                .s,
+            "FAILED"
+        );
+    }
+
+    #[test]
+    fn empty_expected_repo_set_accepts_any_non_empty_repo_set() {
+        let derived = derive_one(server(Status::FAILED, &["software.eessi.io"]), &[]);
+
+        assert_eq!(derived.uptime.pct_90d, 1.0);
+        assert_eq!(
+            derived
+                .bars
+                .iter()
+                .find(|bar| bar.d == "2026-06-13")
+                .unwrap()
+                .s,
+            "OK"
+        );
+    }
+
+    #[test]
+    fn maintenance_status_is_preserved() {
+        let expected = vec!["software.eessi.io".to_string()];
+        let derived = derive_one(
+            server(Status::MAINTENANCE, &["software.eessi.io"]),
+            &expected,
+        );
+
+        assert_eq!(derived.uptime.pct_90d, 0.0);
+        assert_eq!(derived.incidents_90d[0].status, Status::MAINTENANCE);
+        assert_eq!(
+            derived
+                .bars
+                .iter()
+                .find(|bar| bar.d == "2026-06-13")
+                .unwrap()
+                .s,
+            "MAINTENANCE"
+        );
+    }
+}

--- a/src/external.rs
+++ b/src/external.rs
@@ -1,0 +1,326 @@
+use chrono::{DateTime, Duration, Utc};
+use log::{debug, info, warn};
+use reqwest::StatusCode;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use crate::config::{ExternalMetricsConfig, GrafanaMetricsConfig};
+use crate::models::DiskUsagePoint;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExternalError {
+    #[error("missing token env var {0}")]
+    MissingToken(String),
+    #[error("HTTP {status}: {body}")]
+    Http { status: u16, body: String },
+    #[error("auth failed (status {status})")]
+    Auth { status: u16 },
+    #[error("timeout after {seconds}s")]
+    Timeout { seconds: u64 },
+    #[error("malformed response: {0}")]
+    Decode(String),
+    #[error("request failed: {0}")]
+    Request(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalSnapshot {
+    pub source: String,
+    pub fetched_at: DateTime<Utc>,
+    pub stratum1_disk_usage: Vec<DiskUsagePoint>,
+}
+
+pub async fn fetch(src: &ExternalMetricsConfig) -> Result<ExternalSnapshot, ExternalError> {
+    match src {
+        ExternalMetricsConfig::Grafana(cfg) => fetch_grafana(cfg).await,
+    }
+}
+
+async fn fetch_grafana(cfg: &GrafanaMetricsConfig) -> Result<ExternalSnapshot, ExternalError> {
+    let token = std::env::var(&cfg.token_env)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| ExternalError::MissingToken(cfg.token_env.clone()))?;
+    let timeout = std::time::Duration::from_secs(cfg.timeout_seconds);
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .map_err(|e| ExternalError::Request(e.to_string()))?;
+    let fetched_at = Utc::now();
+    let end = fetched_at;
+    let start = end - Duration::weeks(cfg.stratum1_disk_usage.range_weeks as i64);
+    let query = build_query(
+        &cfg.stratum1_disk_usage.query,
+        &cfg.stratum1_disk_usage.instance_regex,
+    );
+    let url = format!(
+        "{}/api/datasources/proxy/uid/{}/api/v1/query_range",
+        cfg.url.trim_end_matches('/'),
+        cfg.datasource_uid
+    );
+    debug!(
+        "fetching external metrics from Grafana: url={}, datasource_uid={}, start={}, end={}, step={}, query={}",
+        cfg.url.trim_end_matches('/'),
+        cfg.datasource_uid,
+        start.to_rfc3339(),
+        end.to_rfc3339(),
+        cfg.stratum1_disk_usage.step,
+        query
+    );
+
+    let mut last_error = None;
+    for attempt in 0..=2 {
+        match query_range(
+            &client,
+            QueryRangeRequest {
+                url: &url,
+                token: &token,
+                query: &query,
+                start,
+                end,
+                step: &cfg.stratum1_disk_usage.step,
+                timeout_seconds: cfg.timeout_seconds,
+            },
+        )
+        .await
+        {
+            Ok(series) => {
+                if series.is_empty() {
+                    warn!(
+                        "external metrics query returned no samples; check stratum1_disk_usage.query and instance_regex; generated query: {query}"
+                    );
+                }
+                return Ok(ExternalSnapshot {
+                    source: "grafana".to_string(),
+                    fetched_at,
+                    stratum1_disk_usage: series,
+                });
+            }
+            Err(err) if is_retryable(&err) && attempt < 2 => {
+                last_error = Some(err);
+                tokio::time::sleep(std::time::Duration::from_millis(250 * (attempt + 1))).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| ExternalError::Request("retry failed".to_string())))
+}
+
+struct QueryRangeRequest<'a> {
+    url: &'a str,
+    token: &'a str,
+    query: &'a str,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    step: &'a str,
+    timeout_seconds: u64,
+}
+
+async fn query_range(
+    client: &reqwest::Client,
+    request: QueryRangeRequest<'_>,
+) -> Result<Vec<DiskUsagePoint>, ExternalError> {
+    let mut url =
+        reqwest::Url::parse(request.url).map_err(|e| ExternalError::Request(e.to_string()))?;
+    url.query_pairs_mut()
+        .append_pair("query", request.query)
+        .append_pair("start", &request.start.to_rfc3339())
+        .append_pair("end", &request.end.to_rfc3339())
+        .append_pair("step", request.step);
+    let response = client
+        .get(url)
+        .bearer_auth(request.token)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                ExternalError::Timeout {
+                    seconds: request.timeout_seconds,
+                }
+            } else {
+                ExternalError::Request(e.to_string())
+            }
+        })?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    debug!(
+        "Grafana query_range HTTP response: status={}, body_bytes={}",
+        status.as_u16(),
+        body.len()
+    );
+    if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+        return Err(ExternalError::Auth {
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(ExternalError::Http {
+            status: status.as_u16(),
+            body: parse_error_body(&body),
+        });
+    }
+    let parsed: PrometheusResponse =
+        serde_json::from_str(&body).map_err(|e| ExternalError::Decode(e.to_string()))?;
+    debug!("Prometheus API response status: {}", parsed.status);
+    if parsed.status != "success" {
+        return Err(ExternalError::Http {
+            status: status.as_u16(),
+            body: parsed
+                .error
+                .unwrap_or_else(|| "Prometheus error".to_string()),
+        });
+    }
+    let result_count = parsed.data.result.len();
+    let value_count = parsed
+        .data
+        .result
+        .iter()
+        .map(|series| series.values.len())
+        .sum::<usize>();
+    info!(
+        "Prometheus query_range succeeded: result_series={}, raw_values={}",
+        result_count, value_count
+    );
+    if result_count == 0 {
+        warn!(
+            "Prometheus query matched no series; generated query: {}",
+            request.query
+        );
+    } else if value_count == 0 {
+        warn!(
+            "Prometheus query matched series but returned no values; generated query: {}",
+            request.query
+        );
+    }
+    let aggregated = aggregate_series(parsed.data.result);
+    info!(
+        "external metrics aggregation produced {} disk usage points",
+        aggregated.len()
+    );
+    if value_count > 0 && aggregated.is_empty() {
+        warn!("Prometheus returned values, but none parsed as finite non-negative byte samples");
+    }
+    Ok(aggregated)
+}
+
+fn is_retryable(err: &ExternalError) -> bool {
+    matches!(
+        err,
+        ExternalError::Timeout { .. }
+            | ExternalError::Request(_)
+            | ExternalError::Http {
+                status: 500..=599,
+                ..
+            }
+    )
+}
+
+fn build_query(template: &str, instance_regex: &str) -> String {
+    template.replace(
+        "{instance_regex}",
+        &escape_promql_string_literal(instance_regex),
+    )
+}
+
+fn escape_promql_string_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(c),
+        }
+    }
+    escaped
+}
+
+fn parse_error_body(body: &str) -> String {
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        #[serde(default)]
+        error: Option<String>,
+        #[serde(default, rename = "errorType")]
+        error_type: Option<String>,
+    }
+    serde_json::from_str::<ErrorBody>(body)
+        .ok()
+        .and_then(|e| match (e.error_type, e.error) {
+            (Some(t), Some(e)) => Some(format!("{t}: {e}")),
+            (None, Some(e)) => Some(e),
+            _ => None,
+        })
+        .unwrap_or_else(|| body.chars().take(200).collect())
+}
+
+fn aggregate_series(results: Vec<PrometheusSeries>) -> Vec<DiskUsagePoint> {
+    let mut by_ts: BTreeMap<i64, f64> = BTreeMap::new();
+    for result in results {
+        for value in result.values {
+            if value.len() != 2 {
+                continue;
+            }
+            let ts = value[0].as_f64().map(|v| v as i64);
+            let bytes = value[1]
+                .as_str()
+                .and_then(|s| s.parse::<f64>().ok())
+                .or_else(|| value[1].as_f64());
+            if let (Some(ts), Some(bytes)) = (ts, bytes) {
+                *by_ts.entry(ts).or_default() += bytes;
+            }
+        }
+    }
+    by_ts
+        .into_iter()
+        .filter_map(|(t, bytes)| {
+            (bytes.is_finite() && bytes >= 0.0).then_some(DiskUsagePoint {
+                t,
+                bytes: bytes.round() as u64,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusResponse {
+    status: String,
+    data: PrometheusData,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusData {
+    result: Vec<PrometheusSeries>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusSeries {
+    values: Vec<Vec<serde_json::Value>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_query, escape_promql_string_literal};
+
+    #[test]
+    fn build_query_escapes_regex_for_promql_string_literal() {
+        let template = r#"metric{instance=~"{instance_regex}",mountpoint="/srv/cvmfs"}"#;
+        let query = build_query(template, r#"stratum1-.*\.eessi\.io"#);
+
+        assert_eq!(
+            query,
+            r#"metric{instance=~"stratum1-.*\\.eessi\\.io",mountpoint="/srv/cvmfs"}"#
+        );
+    }
+
+    #[test]
+    fn escape_promql_string_literal_escapes_special_characters() {
+        assert_eq!(
+            escape_promql_string_literal("host\\name\"x\n"),
+            "host\\\\name\\\"x\\n"
+        );
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,596 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+use log::warn;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use crate::dependencies::atomic_write;
+use crate::models::{DiskUsagePoint, Status, StatusManager, StatusPageData, ToEESSILabel};
+
+pub const HISTORY_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone)]
+pub struct HistoryConfig {
+    pub directory: PathBuf,
+    pub retention_days_raw: u32,
+    pub retention_days_daily: u32,
+    pub expected_repositories: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HistoryStore {
+    root: PathBuf,
+    cfg: HistoryConfig,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CompactionReport {
+    pub invalid_lines: usize,
+    pub raw_retained: usize,
+    pub raw_rolled_up: usize,
+    pub daily_deleted: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HistoryView {
+    pub raw: Vec<Snapshot>,
+    pub daily: Vec<DailyRollup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub v: u8,
+    pub t: i64,
+    pub run_duration_ms: u64,
+    pub overall: Status,
+    pub categories: BTreeMap<String, Status>,
+    pub servers: BTreeMap<String, SnapshotServer>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ext: Option<SnapshotExt>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotServer {
+    #[serde(rename = "type")]
+    pub server_type: String,
+    pub s: Status,
+    pub repos: BTreeMap<String, SnapshotRepo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotRepo {
+    pub r: i32,
+    pub ts: i64,
+    pub cb: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotExt {
+    pub s1_disk_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyRollup {
+    pub v: u8,
+    pub date: String,
+    pub snapshots_count: usize,
+    pub overall: DailyStatusRollup,
+    pub servers: BTreeMap<String, DailyServerRollup>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<DailyExtRollup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyStatusRollup {
+    pub worst: Status,
+    pub ok_fraction: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyServerRollup {
+    pub server_type: String,
+    pub worst: Status,
+    pub ok_fraction: f64,
+    pub observed: usize,
+    pub ok_count: usize,
+    pub transitions: usize,
+    pub last_repos: BTreeMap<String, SnapshotRepo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailyExtRollup {
+    pub s1_disk_bytes_last: u64,
+    pub s1_disk_bytes_max: u64,
+    pub sampled_at: i64,
+}
+
+impl Snapshot {
+    pub fn from_current_state(
+        data: &StatusPageData,
+        status_manager: &StatusManager,
+        run_start: DateTime<Utc>,
+        now: DateTime<Utc>,
+        disk_point: Option<DiskUsagePoint>,
+    ) -> Self {
+        let servers = status_manager
+            .servers
+            .iter()
+            .map(|server| {
+                (
+                    server.hostname.to_string(),
+                    SnapshotServer {
+                        server_type: server.server_type.to_label().to_string(),
+                        s: server.status,
+                        repos: server
+                            .repositories
+                            .iter()
+                            .map(|repo| {
+                                (
+                                    repo.name.clone(),
+                                    SnapshotRepo {
+                                        r: repo.revision,
+                                        ts: repo.manifest.t,
+                                        cb: repo.manifest.b as u64,
+                                    },
+                                )
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            v: HISTORY_SCHEMA_VERSION,
+            t: now.timestamp(),
+            run_duration_ms: (now - run_start).num_milliseconds().max(0) as u64,
+            overall: data.eessi_status.status,
+            categories: BTreeMap::from([
+                ("stratum0".to_string(), data.stratum0.status),
+                ("stratum1".to_string(), data.stratum1.status),
+                ("syncservers".to_string(), data.syncservers.status),
+            ]),
+            servers,
+            ext: disk_point.map(|p| SnapshotExt {
+                s1_disk_bytes: p.bytes,
+            }),
+        }
+    }
+}
+
+impl HistoryStore {
+    pub fn open(cfg: HistoryConfig) -> Result<Self> {
+        fs::create_dir_all(cfg.directory.join("daily"))
+            .with_context(|| format!("failed to create history dir {:?}", cfg.directory))?;
+        Ok(Self {
+            root: cfg.directory.clone(),
+            cfg,
+        })
+    }
+
+    pub fn append(&self, snap: &Snapshot) -> Result<()> {
+        fs::create_dir_all(&self.root)?;
+        let path = self.snapshots_path();
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open {:?}", path))?;
+        serde_json::to_writer(&mut file, snap)?;
+        file.write_all(b"\n")?;
+        Ok(())
+    }
+
+    pub fn compact_and_rotate(&self, now: DateTime<Utc>) -> Result<CompactionReport> {
+        let mut report = CompactionReport::default();
+        let raw_lines = self.read_raw_lines()?;
+        let mut snapshots = Vec::new();
+        for (idx, line) in raw_lines.iter().enumerate() {
+            match serde_json::from_str::<Snapshot>(line) {
+                Ok(snap) => snapshots.push(snap),
+                Err(err) => {
+                    report.invalid_lines += 1;
+                    let preview: String = line.chars().take(80).collect();
+                    warn!(
+                        "{} line {}: {}; first 80 chars: {}",
+                        self.snapshots_path().display(),
+                        idx + 1,
+                        err,
+                        preview
+                    );
+                }
+            }
+        }
+
+        let cutoff_date = (now - Duration::days(self.cfg.retention_days_raw as i64)).date_naive();
+        let (old, recent): (Vec<_>, Vec<_>) = snapshots.into_iter().partition(|s| {
+            Utc.timestamp_opt(s.t, 0)
+                .single()
+                .map(|dt| dt.date_naive() < cutoff_date)
+                .unwrap_or(false)
+        });
+        report.raw_rolled_up = old.len();
+        report.raw_retained = recent.len();
+
+        let mut by_day: BTreeMap<NaiveDate, Vec<Snapshot>> = BTreeMap::new();
+        for snap in old {
+            if let Some(date) = Utc
+                .timestamp_opt(snap.t, 0)
+                .single()
+                .map(|dt| dt.date_naive())
+            {
+                by_day.entry(date).or_default().push(snap);
+            }
+        }
+        for (date, snaps) in by_day {
+            let path = self.daily_path(date);
+            if !path.exists() {
+                let rollup = roll_up(date, &snaps, &self.cfg.expected_repositories);
+                self.write_json_atomic(&path, &rollup)?;
+            }
+        }
+
+        if report.raw_rolled_up > 0 || report.invalid_lines > 0 {
+            let mut text = String::new();
+            for snap in &recent {
+                text.push_str(&serde_json::to_string(snap)?);
+                text.push('\n');
+            }
+            atomic_write(&self.snapshots_path(), text.as_bytes())?;
+        }
+
+        let daily_cutoff = (now - Duration::days(self.cfg.retention_days_daily as i64))
+            .date_naive()
+            .to_string();
+        for entry in fs::read_dir(self.root.join("daily"))? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("json")
+                && path.file_stem().and_then(|s| s.to_str()).unwrap_or("") < daily_cutoff.as_str()
+            {
+                fs::remove_file(&path)?;
+                report.daily_deleted += 1;
+            }
+        }
+        Ok(report)
+    }
+
+    pub fn load_for_window(&self, now: DateTime<Utc>, days: u32) -> Result<HistoryView> {
+        let cutoff = (now - Duration::days(days as i64)).timestamp();
+        let raw = self
+            .read_valid_snapshots()?
+            .into_iter()
+            .filter(|s| s.t >= cutoff)
+            .collect::<Vec<_>>();
+        let daily_cutoff = (now - Duration::days(days as i64)).date_naive();
+        let daily = self.read_daily_rollups(daily_cutoff)?;
+        Ok(HistoryView { raw, daily })
+    }
+
+    pub fn counts(&self) -> Result<(usize, usize)> {
+        Ok((
+            self.read_valid_snapshots()?.len(),
+            self.read_daily_rollups(NaiveDate::MIN)?.len(),
+        ))
+    }
+
+    fn snapshots_path(&self) -> PathBuf {
+        self.root.join("snapshots.jsonl")
+    }
+
+    fn daily_path(&self, date: NaiveDate) -> PathBuf {
+        self.root.join("daily").join(format!("{date}.json"))
+    }
+
+    fn read_raw_lines(&self) -> Result<Vec<String>> {
+        let path = self.snapshots_path();
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(&path)?;
+        BufReader::new(file)
+            .lines()
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    fn read_valid_snapshots(&self) -> Result<Vec<Snapshot>> {
+        let mut snapshots = Vec::new();
+        for (idx, line) in self.read_raw_lines()?.iter().enumerate() {
+            match serde_json::from_str::<Snapshot>(line) {
+                Ok(snap) => snapshots.push(snap),
+                Err(err) => warn!(
+                    "{} line {}: {}; first 80 chars: {}",
+                    self.snapshots_path().display(),
+                    idx + 1,
+                    err,
+                    line.chars().take(80).collect::<String>()
+                ),
+            }
+        }
+        Ok(snapshots)
+    }
+
+    fn read_daily_rollups(&self, cutoff: NaiveDate) -> Result<Vec<DailyRollup>> {
+        let dir = self.root.join("daily");
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut rollups = Vec::new();
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            match fs::read_to_string(&path)
+                .ok()
+                .and_then(|text| serde_json::from_str::<DailyRollup>(&text).ok())
+            {
+                Some(rollup)
+                    if NaiveDate::parse_from_str(&rollup.date, "%Y-%m-%d")
+                        .map(|d| d >= cutoff)
+                        .unwrap_or(false) =>
+                {
+                    rollups.push(rollup)
+                }
+                Some(_) => {}
+                None => warn!("daily history rollup is corrupt: {}", path.display()),
+            }
+        }
+        rollups.sort_by(|a, b| a.date.cmp(&b.date));
+        Ok(rollups)
+    }
+
+    fn write_json_atomic<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
+        let json = serde_json::to_vec_pretty(value)?;
+        atomic_write(path, &json)
+    }
+}
+
+pub fn open_history_store(
+    destination: &Path,
+    cfg: &crate::config::HistorySection,
+    expected_repositories: &[String],
+) -> Result<Option<HistoryStore>> {
+    if !cfg.enabled {
+        return Ok(None);
+    }
+    let directory = if cfg.directory.is_absolute() {
+        cfg.directory.clone()
+    } else {
+        destination.join(&cfg.directory)
+    };
+    HistoryStore::open(HistoryConfig {
+        directory,
+        retention_days_raw: cfg.retention_days_raw,
+        retention_days_daily: cfg.retention_days_daily,
+        expected_repositories: expected_repositories.to_vec(),
+    })
+    .map(Some)
+}
+
+fn roll_up(
+    date: NaiveDate,
+    snapshots: &[Snapshot],
+    expected_repositories: &[String],
+) -> DailyRollup {
+    let mut servers: BTreeMap<String, DailyServerRollup> = BTreeMap::new();
+    let mut previous: HashMap<String, Status> = HashMap::new();
+    let expected_repositories = expected_repositories
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    for snap in snapshots {
+        for (host, server) in &snap.servers {
+            let serving_status = serving_status(server, &expected_repositories);
+            let entry = servers.entry(host.clone()).or_insert(DailyServerRollup {
+                server_type: server.server_type.clone(),
+                worst: serving_status,
+                ok_fraction: 0.0,
+                observed: 0,
+                ok_count: 0,
+                transitions: 0,
+                last_repos: BTreeMap::new(),
+            });
+            entry.worst = entry.worst.max(serving_status);
+            entry.observed += 1;
+            if serving_status == Status::OK {
+                entry.ok_count += 1;
+            }
+            if previous
+                .get(host)
+                .is_some_and(|prev| *prev != serving_status)
+            {
+                entry.transitions += 1;
+            }
+            previous.insert(host.clone(), serving_status);
+            entry.last_repos = server.repos.clone();
+        }
+    }
+    for server in servers.values_mut() {
+        server.ok_fraction = if server.observed == 0 {
+            0.0
+        } else {
+            server.ok_count as f64 / server.observed as f64
+        };
+    }
+    let ok_count = snapshots.iter().filter(|s| s.overall == Status::OK).count();
+    let worst = snapshots
+        .iter()
+        .map(|s| s.overall)
+        .max()
+        .unwrap_or(Status::OK);
+    let ext_points = snapshots
+        .iter()
+        .filter_map(|s| s.ext.as_ref().map(|ext| (s.t, ext.s1_disk_bytes)))
+        .collect::<Vec<_>>();
+    let ext = ext_points.last().map(|(t, last)| DailyExtRollup {
+        s1_disk_bytes_last: *last,
+        s1_disk_bytes_max: ext_points.iter().map(|(_, b)| *b).max().unwrap_or(*last),
+        sampled_at: *t,
+    });
+
+    DailyRollup {
+        v: HISTORY_SCHEMA_VERSION,
+        date: date.to_string(),
+        snapshots_count: snapshots.len(),
+        overall: DailyStatusRollup {
+            worst,
+            ok_fraction: if snapshots.is_empty() {
+                0.0
+            } else {
+                ok_count as f64 / snapshots.len() as f64
+            },
+        },
+        servers,
+        ext,
+    }
+}
+
+fn serving_status(
+    server: &SnapshotServer,
+    expected_repositories: &std::collections::BTreeSet<&String>,
+) -> Status {
+    if server.s == Status::MAINTENANCE {
+        return Status::MAINTENANCE;
+    }
+    if server.repos.is_empty() {
+        return Status::FAILED;
+    }
+    if expected_repositories.is_empty() {
+        return Status::OK;
+    }
+    if expected_repositories
+        .iter()
+        .all(|repo| server.repos.contains_key(repo.as_str()))
+    {
+        Status::OK
+    } else {
+        Status::FAILED
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn snapshot(t: i64) -> Snapshot {
+        Snapshot {
+            v: HISTORY_SCHEMA_VERSION,
+            t,
+            run_duration_ms: 1,
+            overall: Status::OK,
+            categories: BTreeMap::new(),
+            servers: BTreeMap::new(),
+            ext: None,
+        }
+    }
+
+    fn server(status: Status, repos: &[&str]) -> SnapshotServer {
+        SnapshotServer {
+            server_type: "stratum1".to_string(),
+            s: status,
+            repos: repos
+                .iter()
+                .map(|repo| ((*repo).to_string(), SnapshotRepo { r: 1, ts: 1, cb: 1 }))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn compaction_drops_bad_lines() -> Result<()> {
+        let dir = tempdir()?;
+        let store = HistoryStore::open(HistoryConfig {
+            directory: dir.path().join("history"),
+            retention_days_raw: 14,
+            retention_days_daily: 90,
+            expected_repositories: Vec::new(),
+        })?;
+        store.append(&snapshot(1_700_000_000))?;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(store.snapshots_path())?
+            .write_all(b"not json\n")?;
+        let report = store.compact_and_rotate(Utc.timestamp_opt(1_700_000_100, 0).unwrap())?;
+        assert_eq!(report.invalid_lines, 1);
+        let contents = std::fs::read_to_string(store.snapshots_path())?;
+        assert!(!contents.contains("not json"));
+        assert_eq!(store.read_valid_snapshots()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn compaction_keeps_cutoff_day_in_raw_history() -> Result<()> {
+        let dir = tempdir()?;
+        let store = HistoryStore::open(HistoryConfig {
+            directory: dir.path().join("history"),
+            retention_days_raw: 1,
+            retention_days_daily: 90,
+            expected_repositories: Vec::new(),
+        })?;
+        let cutoff_day_snapshot = Utc.with_ymd_and_hms(2026, 6, 13, 0, 1, 0).single().unwrap();
+        let older_snapshot = Utc
+            .with_ymd_and_hms(2026, 6, 12, 23, 59, 0)
+            .single()
+            .unwrap();
+        store.append(&snapshot(cutoff_day_snapshot.timestamp()))?;
+        store.append(&snapshot(older_snapshot.timestamp()))?;
+
+        let report =
+            store.compact_and_rotate(Utc.with_ymd_and_hms(2026, 6, 14, 12, 0, 0).unwrap())?;
+
+        assert_eq!(report.raw_rolled_up, 1);
+        let raw = store.read_valid_snapshots()?;
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].t, cutoff_day_snapshot.timestamp());
+        assert!(store.daily_path(older_snapshot.date_naive()).exists());
+        assert!(!store.daily_path(cutoff_day_snapshot.date_naive()).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn daily_rollup_uses_serving_status_instead_of_revision_status() {
+        let date = NaiveDate::from_ymd_opt(2026, 6, 13).unwrap();
+        let mut failed_but_serving = snapshot(1_781_337_600);
+        failed_but_serving.servers.insert(
+            "s1.example.org".to_string(),
+            server(Status::FAILED, &["software.eessi.io", "dev.eessi.io"]),
+        );
+
+        let rollup = roll_up(
+            date,
+            &[failed_but_serving],
+            &["software.eessi.io".to_string(), "dev.eessi.io".to_string()],
+        );
+
+        let server = rollup.servers.get("s1.example.org").unwrap();
+        assert_eq!(server.worst, Status::OK);
+        assert_eq!(server.ok_count, 1);
+        assert_eq!(server.ok_fraction, 1.0);
+    }
+
+    #[test]
+    fn daily_rollup_marks_missing_expected_repo_failed() {
+        let date = NaiveDate::from_ymd_opt(2026, 6, 13).unwrap();
+        let mut missing_repo = snapshot(1_781_337_600);
+        missing_repo.servers.insert(
+            "s1.example.org".to_string(),
+            server(Status::OK, &["software.eessi.io"]),
+        );
+
+        let rollup = roll_up(
+            date,
+            &[missing_repo],
+            &["software.eessi.io".to_string(), "dev.eessi.io".to_string()],
+        );
+
+        let server = rollup.servers.get("s1.example.org").unwrap();
+        assert_eq!(server.worst, Status::FAILED);
+        assert_eq!(server.ok_count, 0);
+        assert_eq!(server.ok_fraction, 0.0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
-use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, NaiveDate, Utc};
 use clap::Parser;
-use log::{debug, info, trace};
-use std::path::{Path, PathBuf};
+use log::{debug, info, trace, warn};
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
 
 mod config;
 mod dependencies;
+mod derived;
+mod external;
+mod history;
 mod models;
 mod prometheus;
 mod templating;
@@ -13,7 +17,13 @@ mod templating;
 use config::{get_config_manager, init_config};
 use cvmfs_server_scraper::{Scraper, ScraperCommon, ServerType};
 use dependencies::{atomic_write, populate};
-use models::{EESSIStatus, Status, StatusManager, StatusPageData, StratumStatus, ToEESSILabel};
+use derived::DerivedMetrics;
+use external::ExternalSnapshot;
+use history::{open_history_store, HistoryView, Snapshot};
+use models::{
+    DiskUsageJson, DiskUsagePoint, EESSIStatus, ExternalMetricsJson, HistoryMeta, Status,
+    StatusManager, StatusPageData, StratumStatus, ToEESSILabel, TrendsPageData,
+};
 use prometheus::MetricsBuilder;
 use templating::{render_template_to_file, RepoStatus, StatusInfo};
 
@@ -65,6 +75,20 @@ struct Opt {
     json_output_file: PathBuf,
 
     #[arg(
+        long,
+        default_value = "trends.html",
+        help = "Filename for the generated trends page, will be placed in the destination directory."
+    )]
+    trends_output_file: PathBuf,
+
+    #[arg(
+        long,
+        default_value = "trends.json",
+        help = "Filename for the generated trends JSON, will be placed in the destination directory."
+    )]
+    trends_json_output_file: PathBuf,
+
+    #[arg(
         short,
         long,
         help = "Generate a prometheus-style metrics/index.html in the destination directory."
@@ -87,13 +111,46 @@ async fn main() -> Result<()> {
         std::process::exit(0);
     }
 
-    let status_manager = create_status_manager(config_manager).await?;
-    let status_page_data = generate_status_page_data(config_manager, &status_manager)?;
+    validate_output_path(&args.output_file)?;
+    validate_output_path(&args.json_output_file)?;
+    validate_output_path(&args.trends_output_file)?;
+    validate_output_path(&args.trends_json_output_file)?;
 
-    render_output(&args, &status_page_data)?;
+    let status_manager = create_status_manager(config_manager).await?;
+    let mut status_page_data = generate_status_page_data(config_manager, &status_manager)?;
+    apply_urls(&args, &mut status_page_data);
+
+    let external_snapshot = fetch_external(config_manager).await;
+    let latest_disk_point = external_snapshot
+        .as_ref()
+        .and_then(|snap| snap.stratum1_disk_usage.last().copied());
+    let history = process_history(
+        &args,
+        config_manager,
+        &mut status_page_data,
+        &status_manager,
+        run_start_time,
+        latest_disk_point,
+    );
+    let trends = build_trends_data(
+        &args,
+        config_manager,
+        &status_page_data,
+        history.as_ref(),
+        external_snapshot.as_ref(),
+        &chrono::Utc::now(),
+    );
+
+    render_output(&args, &status_page_data, &trends)?;
 
     if args.prometheus_metrics {
-        generate_prometheus_metrics(&args, &status_page_data, &status_manager, &run_start_time)?;
+        generate_prometheus_metrics(
+            &args,
+            &status_page_data,
+            &status_manager,
+            &run_start_time,
+            history.as_ref().map(|(_, d)| d),
+        )?;
     }
 
     Ok(())
@@ -176,7 +233,301 @@ fn generate_status_page_data(
         repositories: status_manager.details_repositories(),
         config: config_manager.config.read().unwrap().clone(),
         servers: status_manager.get_server_status_for_all(),
+        summary: Some(status_manager.current_summary()),
+        repositories_enriched: status_manager.repositories_enriched(),
+        servers_enriched: status_manager.servers_enriched(),
+        history_meta: None,
+        trends_url: "trends.html".to_string(),
+        history_url: "history.json".to_string(),
+        asset_base_url: String::new(),
     })
+}
+
+fn validate_output_path(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        bail!("output path must be relative: {:?}", path);
+    }
+    for component in path.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            bail!("output path may not escape destination: {:?}", path);
+        }
+    }
+    Ok(())
+}
+
+fn apply_urls(args: &Opt, data: &mut StatusPageData) {
+    data.trends_url = relative_url_from_file(&args.output_file, &args.trends_output_file);
+    data.history_url = relative_url_from_file(&args.output_file, Path::new("history.json"));
+    data.asset_base_url = asset_base_from_file(&args.output_file);
+}
+
+async fn fetch_external(config_manager: &config::ConfigManager) -> Option<ExternalSnapshot> {
+    let config = config_manager.get_config();
+    match config.external_metrics.as_ref() {
+        Some(cfg) => match external::fetch(cfg).await {
+            Ok(snapshot) => Some(snapshot),
+            Err(err) => {
+                warn!("external metrics unavailable: {err}");
+                None
+            }
+        },
+        None => None,
+    }
+}
+
+fn process_history(
+    args: &Opt,
+    config_manager: &config::ConfigManager,
+    status_page_data: &mut StatusPageData,
+    status_manager: &StatusManager,
+    run_start_time: DateTime<Utc>,
+    latest_disk_point: Option<DiskUsagePoint>,
+) -> Option<(HistoryView, DerivedMetrics)> {
+    let config = config_manager.get_config();
+    let now = chrono::Utc::now();
+    let store = match open_history_store(&args.destination, &config.history, &config.repositories) {
+        Ok(Some(store)) => store,
+        Ok(None) => return None,
+        Err(err) => {
+            warn!("history store unavailable: {err}");
+            return None;
+        }
+    };
+    let snap = Snapshot::from_current_state(
+        status_page_data,
+        status_manager,
+        run_start_time,
+        now,
+        latest_disk_point,
+    );
+    if let Err(err) = store.append(&snap) {
+        warn!("history append failed: {err}");
+    }
+    if let Err(err) = store.compact_and_rotate(now) {
+        warn!("history compaction failed: {err}");
+    }
+    let view = match store.load_for_window(now, config.history.bucket_window_days) {
+        Ok(view) => view,
+        Err(err) => {
+            warn!("history load failed: {err}");
+            return None;
+        }
+    };
+    let derived = derived::derive(
+        &view,
+        now,
+        config.history.bucket_window_days,
+        &config.repositories,
+    );
+    enrich_status_with_history(status_page_data, &derived);
+    let history_json =
+        derived::build_history_json(&derived, now, config.history.bucket_window_days);
+    if let Err(err) = write_json_file(&history_json, &args.destination, Path::new("history.json")) {
+        warn!("history.json write failed: {err}");
+    }
+    let (raw_count, daily_count) = store.counts().unwrap_or((view.raw.len(), view.daily.len()));
+    let earliest = view
+        .raw
+        .iter()
+        .map(|s| s.t)
+        .chain(view.daily.iter().filter_map(|d| day_start_ts(&d.date)))
+        .min();
+    let latest = view.raw.iter().map(|s| s.t).max();
+    status_page_data.history_meta = Some(HistoryMeta {
+        url: status_page_data.history_url.clone(),
+        bucket_window_days: config.history.bucket_window_days,
+        snapshots_raw: raw_count,
+        snapshots_daily: daily_count,
+        earliest_snapshot: earliest,
+        latest_snapshot: latest,
+        schema_version: history::HISTORY_SCHEMA_VERSION,
+    });
+    Some((view, derived))
+}
+
+fn enrich_status_with_history(data: &mut StatusPageData, derived: &DerivedMetrics) {
+    for server in &mut data.servers_enriched {
+        if let Some(d) = derived.servers.get(&server.hostname) {
+            server.uptime = Some(d.uptime.clone());
+            server.incidents_90d = d.incidents_90d.clone();
+        }
+    }
+}
+
+fn build_trends_data(
+    args: &Opt,
+    config_manager: &config::ConfigManager,
+    status_page_data: &StatusPageData,
+    history: Option<&(HistoryView, DerivedMetrics)>,
+    external_snapshot: Option<&ExternalSnapshot>,
+    now: &DateTime<Utc>,
+) -> TrendsPageData {
+    let config = config_manager.get_config();
+    let external_metrics =
+        build_external_metrics(&config, history.map(|(v, _)| v), external_snapshot);
+    TrendsPageData {
+        v: 1,
+        generated_at: now.timestamp(),
+        back_url: relative_url_from_file(&args.trends_output_file, &args.output_file),
+        status_json_url: relative_url_from_file(&args.trends_output_file, &args.json_output_file),
+        trends_json_url: relative_url_from_file(
+            &args.trends_output_file,
+            &args.trends_json_output_file,
+        ),
+        asset_base_url: asset_base_from_file(&args.trends_output_file),
+        title: "EESSI trends!".to_string(),
+        contact_email: status_page_data.contact_email.clone(),
+        external_metrics_configured: config.external_metrics.is_some(),
+        external_metrics,
+    }
+}
+
+fn build_external_metrics(
+    config: &config::ConfigFile,
+    history: Option<&HistoryView>,
+    external_snapshot: Option<&ExternalSnapshot>,
+) -> Option<ExternalMetricsJson> {
+    let ext_cfg = config.external_metrics.as_ref()?;
+    let history_series = history_disk_points(history);
+    let (series, fallback_from_history, fetched_at) = if let Some(snap) = external_snapshot {
+        (
+            merge_disk_points(&history_series, &snap.stratum1_disk_usage),
+            false,
+            Some(snap.fetched_at.timestamp()),
+        )
+    } else if !history_series.is_empty() {
+        (history_series, true, None)
+    } else {
+        return None;
+    };
+    if series.is_empty() {
+        warn!("external metrics are configured, but no live or historical disk usage samples are available for trends");
+        return None;
+    }
+    let current = series.last()?.bytes;
+    let max = series.iter().map(|p| p.bytes).max().unwrap_or(current);
+    info!(
+        "building trends external metrics: source={}, points={}, fallback_from_history={}, current={}",
+        if external_snapshot.is_some() {
+            "grafana"
+        } else {
+            "history"
+        },
+        series.len(),
+        fallback_from_history,
+        format_bytes(current)
+    );
+    Some(ExternalMetricsJson {
+        source: external_snapshot
+            .map(|s| s.source.clone())
+            .unwrap_or_else(|| match ext_cfg {
+                config::ExternalMetricsConfig::Grafana(_) => "grafana".to_string(),
+            }),
+        fetched_at,
+        sampled_at: series.last().map(|p| p.t),
+        fallback_from_history,
+        stratum1_disk_usage: DiskUsageJson {
+            unit: "bytes".to_string(),
+            current_bytes: current,
+            current_human: format_bytes(current),
+            max_bytes_52w: max,
+            max_human_52w: format_bytes(max),
+            series,
+        },
+    })
+}
+
+fn history_disk_points(history: Option<&HistoryView>) -> Vec<DiskUsagePoint> {
+    let Some(history) = history else {
+        return Vec::new();
+    };
+    let mut points = history
+        .daily
+        .iter()
+        .filter_map(|d| {
+            d.ext.as_ref().map(|ext| DiskUsagePoint {
+                t: ext.sampled_at,
+                bytes: ext.s1_disk_bytes_last,
+            })
+        })
+        .chain(history.raw.iter().filter_map(|s| {
+            s.ext.as_ref().map(|ext| DiskUsagePoint {
+                t: s.t,
+                bytes: ext.s1_disk_bytes,
+            })
+        }))
+        .collect::<Vec<_>>();
+    points.sort_by_key(|p| p.t);
+    points.dedup_by_key(|p| p.t);
+    points
+}
+
+fn merge_disk_points(history: &[DiskUsagePoint], live: &[DiskUsagePoint]) -> Vec<DiskUsagePoint> {
+    let mut map = BTreeMap::new();
+    for point in history {
+        map.insert(point.t, *point);
+    }
+    for point in live {
+        map.insert(point.t, *point);
+    }
+    map.into_values().collect()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const TB: f64 = 1_000_000_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    if bytes as f64 >= TB {
+        format!("{:.2} TB", bytes as f64 / TB)
+    } else if bytes as f64 >= GB {
+        format!("{:.1} GB", bytes as f64 / GB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn relative_url_from_file(from_file: &Path, to: &Path) -> String {
+    let from_parent = from_file.parent().unwrap_or_else(|| Path::new(""));
+    let up_count = from_parent
+        .components()
+        .filter(|c| matches!(c, Component::Normal(_)))
+        .count();
+    let mut parts = Vec::new();
+    for _ in 0..up_count {
+        parts.push("..".to_string());
+    }
+    for component in to.components() {
+        if let Component::Normal(part) = component {
+            parts.push(part.to_string_lossy().to_string());
+        }
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn asset_base_from_file(from_file: &Path) -> String {
+    let from_parent = from_file.parent().unwrap_or_else(|| Path::new(""));
+    let up_count = from_parent
+        .components()
+        .filter(|c| matches!(c, Component::Normal(_)))
+        .count();
+    if up_count == 0 {
+        String::new()
+    } else {
+        "../".repeat(up_count)
+    }
+}
+
+fn day_start_ts(date: &str) -> Option<i64> {
+    NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .map(|dt| dt.and_utc().timestamp())
 }
 
 fn generate_prometheus_metrics(
@@ -184,6 +535,7 @@ fn generate_prometheus_metrics(
     status_page_data: &StatusPageData,
     status_manager: &StatusManager,
     timestamp: &DateTime<Utc>,
+    derived: Option<&DerivedMetrics>,
 ) -> Result<()> {
     use crate::models::StatusLevel;
 
@@ -306,6 +658,81 @@ fn generate_prometheus_metrics(
         }
     }
 
+    if let Some(derived) = derived {
+        for (server, data) in &derived.servers {
+            let labels: [(&str, &str); 2] = [("type", &data.server_type), ("server", server)];
+            b.add_gauge(
+                "server_uptime_pct_30d",
+                "Server uptime percentage over observed samples in 30 days",
+                data.uptime.pct_30d,
+                &labels,
+                Some(ts),
+            )
+            .add_gauge(
+                "server_uptime_pct_90d",
+                "Server uptime percentage over observed samples in 90 days",
+                data.uptime.pct_90d,
+                &labels,
+                Some(ts),
+            )
+            .add_gauge(
+                "server_longest_outage_seconds_90d",
+                "Server longest outage seconds in 90 days",
+                data.uptime.longest_outage_seconds_90d as f64,
+                &labels,
+                Some(ts),
+            );
+            if let Some(mttr) = data.uptime.mttr_seconds_90d {
+                b.add_gauge(
+                    "server_mttr_seconds_90d",
+                    "Server mean time to recovery seconds in 90 days",
+                    mttr as f64,
+                    &labels,
+                    Some(ts),
+                );
+            }
+        }
+        for (repo, data) in &derived.repositories {
+            let labels: [(&str, &str); 1] = [("repository", repo)];
+            if let Some(v) = data.sync_lag_p50_30d {
+                b.add_gauge(
+                    "repo_sync_lag_seconds_p50_30d",
+                    "Repository sync lag p50 seconds in 30 days",
+                    v as f64,
+                    &labels,
+                    Some(ts),
+                );
+            }
+            if let Some(v) = data.sync_lag_p95_30d {
+                b.add_gauge(
+                    "repo_sync_lag_seconds_p95_30d",
+                    "Repository sync lag p95 seconds in 30 days",
+                    v as f64,
+                    &labels,
+                    Some(ts),
+                );
+            }
+            if let Some(v) = data.sync_lag_max_30d {
+                b.add_gauge(
+                    "repo_sync_lag_seconds_max_30d",
+                    "Repository sync lag max seconds in 30 days",
+                    v as f64,
+                    &labels,
+                    Some(ts),
+                );
+            }
+            if let Some(v) = data.revisions_per_week_30d {
+                b.add_gauge(
+                    "repo_revisions_per_week_30d",
+                    "Repository revisions per week in 30 days",
+                    v,
+                    &labels,
+                    Some(ts),
+                );
+            }
+        }
+    }
+
     let text = b.build();
     atomic_write(&filename, text.as_bytes())?;
     info!("Prometheus metrics file written to: {:?}", filename);
@@ -362,36 +789,110 @@ fn create_repo_status() -> RepoStatus {
     }
 }
 
-fn render_output(args: &Opt, status_page_data: &StatusPageData) -> Result<()> {
-    let mut context = tera::Context::new();
-    context.insert("data", status_page_data);
-
+fn render_output(
+    args: &Opt,
+    status_page_data: &StatusPageData,
+    trends_page_data: &TrendsPageData,
+) -> Result<()> {
     let destination = args
         .destination
         .to_str()
         .context("Invalid destination path")?;
-    let output_file = args
-        .output_file
-        .to_str()
-        .context("Invalid output file path")?;
 
     populate(destination, args.force_resource_creation)?;
-    render_template_to_file("status.html", &context, destination, output_file)?;
-    generate_json_output(status_page_data, &args.destination, &args.json_output_file)?;
+    let mut status_context = tera::Context::new();
+    status_context.insert("data", status_page_data);
+    render_template_to_file(
+        "status.html",
+        &status_context,
+        destination,
+        path_to_str(&args.output_file)?,
+    )?;
+    write_json_file(status_page_data, &args.destination, &args.json_output_file)?;
+
+    let mut trends_context = tera::Context::new();
+    trends_context.insert("data", trends_page_data);
+    if let Err(err) = render_template_to_file(
+        "trends.html",
+        &trends_context,
+        destination,
+        path_to_str(&args.trends_output_file)?,
+    ) {
+        warn!("trends render failed: {err}");
+        write_trends_fallback(args, &err.to_string())?;
+    }
+    if let Err(err) = write_json_file(
+        trends_page_data,
+        &args.destination,
+        &args.trends_json_output_file,
+    ) {
+        warn!("trends.json write failed: {err}");
+        write_trends_fallback(args, &err.to_string())?;
+    }
 
     Ok(())
 }
 
-fn generate_json_output(
-    data: &StatusPageData,
+fn write_json_file<T: serde::Serialize>(
+    data: &T,
     destination: &Path,
-    filename: &PathBuf,
+    filename: &Path,
 ) -> Result<()> {
     let fqfn = destination.join(filename);
+    if let Some(parent) = fqfn.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     trace!("Generating JSON output file: {:?}", fqfn);
 
     let json = serde_json::to_string_pretty(data)?;
     atomic_write(&fqfn, json.as_bytes())?;
     info!("JSON output file written to: {:?}", fqfn);
     Ok(())
+}
+
+fn write_trends_fallback(args: &Opt, err: &str) -> Result<()> {
+    let path = args.destination.join(&args.trends_output_file);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let back_url = relative_url_from_file(&args.trends_output_file, &args.output_file);
+    let html = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>Trends unavailable</title></head><body><h1>Trends temporarily unavailable</h1><p>{}</p><p>{}</p><p><a href=\"{}\">Back</a></p></body></html>",
+        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        err,
+        back_url
+    );
+    atomic_write(&path, html.as_bytes())
+}
+
+fn path_to_str(path: &Path) -> Result<&str> {
+    path.to_str().context("Invalid output path")
+}
+
+#[cfg(test)]
+mod integration_helpers_tests {
+    use super::*;
+
+    #[test]
+    fn relative_urls_handle_nested_outputs() {
+        assert_eq!(
+            relative_url_from_file(
+                Path::new("status/index.html"),
+                Path::new("trends/index.html")
+            ),
+            "../trends/index.html"
+        );
+        assert_eq!(
+            relative_url_from_file(Path::new("trends/index.html"), Path::new("index.html")),
+            "../index.html"
+        );
+        assert_eq!(asset_base_from_file(Path::new("trends/index.html")), "../");
+    }
+
+    #[test]
+    fn output_paths_may_not_escape_destination() {
+        assert!(validate_output_path(Path::new("nested/index.html")).is_ok());
+        assert!(validate_output_path(Path::new("../index.html")).is_err());
+        assert!(validate_output_path(Path::new("/tmp/index.html")).is_err());
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -137,6 +137,212 @@ pub struct StatusPageData {
     pub repositories: Vec<RepoStatus>,
     pub config: ConfigFile,
     pub servers: Vec<ServerStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<StatusSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub repositories_enriched: Vec<RepositoryEnriched>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub servers_enriched: Vec<ServerEnriched>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_meta: Option<HistoryMeta>,
+    pub trends_url: String,
+    pub history_url: String,
+    pub asset_base_url: String,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct StatusSummary {
+    pub stratum0_count: usize,
+    pub stratum1_count: usize,
+    pub syncserver_count: usize,
+    pub repo_count: usize,
+    pub total_catalogue_size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worst_sync_lag_seconds: Option<i64>,
+    pub geographic_spread: GeographicSpread,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct GeographicSpread {
+    pub stratum1_countries: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct RepositoryEnriched {
+    pub name: String,
+    pub status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stratum0_revision: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stratum0_timestamp: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stratum1_min_revision: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stratum1_max_revision: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub divergence: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_lag_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalogue_size_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ServerEnriched {
+    pub hostname: String,
+    pub server_type: String,
+    pub status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub geo: Option<ServerGeo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime: Option<ServerUptime>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub incidents_90d: Vec<Incident>,
+    pub repositories: Vec<ServerRepositoryEnriched>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ServerGeo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lat: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lon: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct ServerUptime {
+    pub pct_30d: f64,
+    pub pct_90d: f64,
+    pub observed_samples_30d: usize,
+    pub observed_samples_90d: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_ok_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure_at: Option<i64>,
+    pub longest_outage_seconds_90d: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mttr_seconds_90d: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Incident {
+    pub start: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<i64>,
+    pub duration_seconds: i64,
+    pub status: Status,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ServerRepositoryEnriched {
+    pub name: String,
+    pub revision: i32,
+    pub timestamp: i64,
+    pub catalogue_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct HistoryMeta {
+    pub url: String,
+    pub bucket_window_days: u32,
+    pub snapshots_raw: usize,
+    pub snapshots_daily: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub earliest_snapshot: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_snapshot: Option<i64>,
+    pub schema_version: u8,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct HistoryJson {
+    pub v: u8,
+    pub generated_at: i64,
+    pub bucket_window_days: u32,
+    pub servers: std::collections::BTreeMap<String, HistoryServerJson>,
+    pub repositories: std::collections::BTreeMap<String, HistoryRepoJson>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct HistoryServerJson {
+    pub server_type: String,
+    pub uptime: ServerUptime,
+    pub bars: Vec<HistoryBar>,
+    pub incidents_90d: Vec<Incident>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct HistoryBar {
+    pub d: String,
+    pub s: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ok_fraction: Option<f64>,
+    pub transitions: usize,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct HistoryRepoJson {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_lag_p50_30d: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_lag_p95_30d: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_lag_max_30d: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revisions_per_week_30d: Option<f64>,
+    pub revision_series: Vec<RevisionPoint>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct RevisionPoint {
+    pub t: i64,
+    pub r: i32,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct TrendsPageData {
+    pub v: u8,
+    pub generated_at: i64,
+    pub back_url: String,
+    pub status_json_url: String,
+    pub trends_json_url: String,
+    pub asset_base_url: String,
+    pub title: String,
+    pub contact_email: String,
+    pub external_metrics_configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_metrics: Option<ExternalMetricsJson>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ExternalMetricsJson {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fetched_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampled_at: Option<i64>,
+    pub fallback_from_history: bool,
+    pub stratum1_disk_usage: DiskUsageJson,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiskUsageJson {
+    pub unit: String,
+    pub current_bytes: u64,
+    pub current_human: String,
+    pub max_bytes_52w: u64,
+    pub max_human_52w: String,
+    pub series: Vec<DiskUsagePoint>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct DiskUsagePoint {
+    pub t: i64,
+    pub bytes: u64,
 }
 
 pub trait HasStatusField {
@@ -328,6 +534,137 @@ impl StatusManager {
             .into_iter()
             .map(Server::to_server_status)
             .collect()
+    }
+
+    pub fn current_summary(&self) -> StatusSummary {
+        let mut countries = Vec::<String>::new();
+        countries.sort();
+        countries.dedup();
+
+        let total_catalogue_size_bytes = self
+            .servers
+            .iter()
+            .flat_map(|s| s.repositories.iter())
+            .map(|r| r.manifest.b as u64)
+            .sum();
+
+        StatusSummary {
+            stratum0_count: self.get_by_type(ServerType::Stratum0).len(),
+            stratum1_count: self.get_by_type(ServerType::Stratum1).len(),
+            syncserver_count: self.get_by_type(ServerType::SyncServer).len(),
+            repo_count: self.get_status_per_unique_repo().len(),
+            total_catalogue_size_bytes,
+            worst_sync_lag_seconds: self.worst_sync_lag_seconds(),
+            geographic_spread: GeographicSpread {
+                stratum1_countries: countries,
+            },
+        }
+    }
+
+    pub fn repositories_enriched(&self) -> Vec<RepositoryEnriched> {
+        let repo_status = self.get_status_per_unique_repo();
+        let mut names = repo_status.keys().cloned().collect::<Vec<_>>();
+        names.sort();
+
+        names
+            .into_iter()
+            .map(|name| {
+                let stratum0_repo = self
+                    .servers
+                    .iter()
+                    .find(|s| s.server_type == ServerType::Stratum0)
+                    .and_then(|s| s.repositories.iter().find(|r| r.name == name));
+                let stratum1_revisions = self
+                    .servers
+                    .iter()
+                    .filter(|s| s.server_type == ServerType::Stratum1)
+                    .flat_map(|s| s.repositories.iter().filter(|r| r.name == name))
+                    .map(|r| r.revision)
+                    .collect::<Vec<_>>();
+                let stratum1_timestamps = self
+                    .servers
+                    .iter()
+                    .filter(|s| s.server_type == ServerType::Stratum1)
+                    .flat_map(|s| s.repositories.iter().filter(|r| r.name == name))
+                    .map(|r| r.manifest.t)
+                    .collect::<Vec<_>>();
+                let stratum1_min_revision = stratum1_revisions.iter().min().copied();
+                let stratum1_max_revision = stratum1_revisions.iter().max().copied();
+                let divergence = match (stratum1_min_revision, stratum1_max_revision) {
+                    (Some(min), Some(max)) => Some(max - min),
+                    _ => None,
+                };
+                let sync_lag_seconds = stratum0_repo.and_then(|s0| {
+                    stratum1_timestamps
+                        .iter()
+                        .min()
+                        .map(|min_ts| (s0.manifest.t - min_ts).max(0))
+                });
+                let catalogue_size_bytes =
+                    stratum0_repo.map(|r| r.manifest.b as u64).or_else(|| {
+                        self.servers
+                            .iter()
+                            .flat_map(|s| s.repositories.iter())
+                            .find(|r| r.name == name)
+                            .map(|r| r.manifest.b as u64)
+                    });
+
+                RepositoryEnriched {
+                    name: name.clone(),
+                    status: *repo_status.get(&name).unwrap_or(&Status::OK),
+                    stratum0_revision: stratum0_repo.map(|r| r.revision),
+                    stratum0_timestamp: stratum0_repo.map(|r| r.manifest.t),
+                    stratum1_min_revision,
+                    stratum1_max_revision,
+                    divergence,
+                    sync_lag_seconds,
+                    catalogue_size_bytes,
+                    ttl_seconds: stratum0_repo.map(|r| r.manifest.d as i64),
+                }
+            })
+            .collect()
+    }
+
+    pub fn servers_enriched(&self) -> Vec<ServerEnriched> {
+        self.servers
+            .iter()
+            .map(|server| ServerEnriched {
+                hostname: server.hostname.to_string(),
+                server_type: server.server_type.to_label().to_string(),
+                status: server.status,
+                geo: None,
+                uptime: None,
+                incidents_90d: Vec::new(),
+                repositories: server
+                    .repositories
+                    .iter()
+                    .map(|repo| ServerRepositoryEnriched {
+                        name: repo.name.clone(),
+                        revision: repo.revision,
+                        timestamp: repo.manifest.t,
+                        catalogue_size_bytes: repo.manifest.b as u64,
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    pub fn worst_sync_lag_seconds(&self) -> Option<i64> {
+        let stratum0s = self.get_by_type(ServerType::Stratum0);
+        let stratum0 = stratum0s.first()?;
+        self.servers
+            .iter()
+            .filter(|s| s.server_type == ServerType::Stratum1)
+            .flat_map(|s1| {
+                s1.repositories.iter().filter_map(|repo| {
+                    stratum0
+                        .repositories
+                        .iter()
+                        .find(|r| r.name == repo.name)
+                        .map(|s0_repo| (s0_repo.manifest.t - repo.manifest.t).max(0))
+                })
+            })
+            .max()
     }
 
     #[allow(dead_code)]

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -27,11 +27,16 @@ pub fn render_template_to_file(
 ) -> Result<()> {
     let rendered = render_template(template_name, context)?;
     let fqfn = Path::new(destination).join(filename);
-
-    let mut tmpfile = NamedTempFile::new_in(destination).context(format!(
-        "Failed to create temporary file in {}",
-        destination
+    let parent = fqfn
+        .parent()
+        .context(format!("Invalid template output path: {:?}", fqfn))?;
+    std::fs::create_dir_all(parent).context(format!(
+        "Failed to create template output directory: {:?}",
+        parent
     ))?;
+
+    let mut tmpfile = NamedTempFile::new_in(parent)
+        .context(format!("Failed to create temporary file in {:?}", parent))?;
 
     trace!("Writing to temporary file: {:?}", tmpfile.path());
     tmpfile
@@ -193,6 +198,54 @@ mod tests {
         assert!(serialized.contains(name));
         assert!(serialized.contains(revision_class));
         assert!(serialized.contains(snapshot_class));
+        Ok(())
+    }
+
+    #[test]
+    fn test_templates_parse() -> Result<()> {
+        init_templates()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_status_and_trends_templates_render_with_minimal_context() -> Result<()> {
+        let mut status_context = tera::Context::new();
+        status_context.insert(
+            "data",
+            &serde_json::json!({
+                "title": "Test",
+                "asset_base_url": "",
+                "history_url": "history.json",
+                "trends_url": "trends.html",
+                "eessi_status": {"class": "status-ok", "text": "OK", "description": "OK"},
+                "legend": [],
+                "stratum0": {"status_class": "status-ok", "details": []},
+                "stratum1": {"status_class": "status-ok", "servers": []},
+                "syncservers": {"status_class": "status-ok", "servers": []},
+                "repositories_status": {"revision_class": "status-ok"},
+                "repositories": [],
+                "history_meta": null,
+                "last_update": "2026-06-11T00:00:00Z",
+                "contact_email": "test@example.com"
+            }),
+        );
+        render_template("status.html", &status_context)?;
+
+        let mut trends_context = tera::Context::new();
+        trends_context.insert(
+            "data",
+            &serde_json::json!({
+                "title": "Test trends",
+                "asset_base_url": "",
+                "back_url": "index.html",
+                "trends_json_url": "trends.json",
+                "external_metrics_configured": false,
+                "external_metrics": null,
+                "generated_at": 0,
+                "contact_email": "test@example.com"
+            }),
+        );
+        render_template("trends.html", &trends_context)?;
         Ok(())
     }
 }

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -1,0 +1,15 @@
+<div class="footer">
+    Last updated {{ last_update }} |
+    {% if active == "status" %}
+    <span>status</span>
+    {% else %}
+    <a href="{{ status_url }}">status</a>
+    {% endif %}
+    |
+    {% if active == "trends" %}
+    <span>trends</span>
+    {% else %}
+    <a href="{{ trends_url }}">trends</a>
+    {% endif %}
+    | {{ contact_email }}
+</div>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,0 +1,8 @@
+<div class="header-row">
+    <div class="header-text">
+        <div class="content site-header">
+            <h1 class="content-left">{{ title }}</h1>
+            <img class="content-right inline logo" src="{{ asset_base_url }}eessi-512px.png" width="75px" />
+        </div>
+    </div>
+</div>

--- a/templates/status.html
+++ b/templates/status.html
@@ -4,23 +4,24 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
-    <link rel="stylesheet" type="text/css" href="status.css">
-    <link rel="stylesheet" type="text/css" href="fa.all.min.css">
-    <script src="status.js" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="{{ data.asset_base_url }}status.css">
+    <link rel="stylesheet" type="text/css" href="{{ data.asset_base_url }}fa.all.min.css">
+    <script>
+        window.STATUS_HISTORY_URL = "{{ data.history_url }}";
+    </script>
+    <script src="{{ data.asset_base_url }}status.js" type="text/javascript"></script>
 
     <title>{{ data.title }}</title>
 </head>
 
 <body>
 
-    <div class="header-row">
-        <div class="header-text">
-            <div class="content">
-                <h1 class="content-left">{{ data.title }}</h1>
-                <img class="content-right inline" src="eessi-512px.png" width="75px" />
-            </div>
-        </div>
-    </div>
+    {% set title = data.title %}
+    {% set active = "status" %}
+    {% set status_url = "#" %}
+    {% set trends_url = data.trends_url %}
+    {% set asset_base_url = data.asset_base_url %}
+    {% include "_header.html" %}
 
     <div class="content-row">
 
@@ -136,9 +137,20 @@
                 </div>
             </div>
         </div>
+
+        {% if data.history_meta %}
+        <div class="history-panel">
+            <h2>Recent history</h2>
+            <div id="history-bars" data-history-url="{{ data.history_url }}">
+                <p class="muted">Loading history...</p>
+            </div>
+        </div>
+        {% endif %}
     </div>
 
-    <div class="footer">Last updated {{ data.last_update }} | {{ data.contact_email }}</div>
+    {% set last_update = data.last_update %}
+    {% set contact_email = data.contact_email %}
+    {% include "_footer.html" %}
 
 </body>
 

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+    <link rel="stylesheet" type="text/css" href="{{ data.asset_base_url }}status.css">
+    <link rel="stylesheet" type="text/css" href="{{ data.asset_base_url }}fa.all.min.css">
+    <script>
+        window.TRENDS_JSON_URL = "{{ data.trends_json_url }}";
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="{{ data.asset_base_url }}trends.js" type="text/javascript"></script>
+    <title>{{ data.title }}</title>
+</head>
+
+<body>
+    {% set title = data.title %}
+    {% set active = "trends" %}
+    {% set status_url = data.back_url %}
+    {% set trends_url = "#" %}
+    {% set asset_base_url = data.asset_base_url %}
+    {% include "_header.html" %}
+
+    <div class="content-row">
+        {% if data.external_metrics_configured %}
+        <section class="infobox trends-section">
+            <h2>Stratum1 disk usage</h2>
+            <div id="disk-usage-chart" class="trends-chart-panel" data-trends-json-url="{{ data.trends_json_url }}">
+                <p class="muted">Loading disk usage...</p>
+            </div>
+        </section>
+        {% endif %}
+
+        {% if not data.external_metrics_configured %}
+        <section class="infobox trends-section">
+            <h2>No capacity data configured</h2>
+            <p>Enable an external metric source to render shared Stratum1 disk usage.</p>
+            <p><a href="{{ data.back_url }}">Back to status</a></p>
+        </section>
+        {% endif %}
+    </div>
+
+    {% set last_update = data.generated_at %}
+    {% set contact_email = data.contact_email %}
+    {% include "_footer.html" %}
+</body>
+
+</html>


### PR DESCRIPTION
- Add persisted history storage with raw JSONL snapshots, daily rollups, retention controls, and derived 30/90-day reliability metrics
- Generate enriched `status.json`, public `history.json`, and configurable `trends.html`/`trends.json` outputs
- Add trends page assets/templates and shared header/footer templates for status and trends pages
- Support optional Grafana-backed Stratum 1 disk usage metrics with history fallback
- Extend Prometheus output with history-derived server uptime/outage and repository sync/revision trend gauges
- Add config defaults for history and external metrics, plus CLI options for trends output paths
- Update README and split out dedicated docs for Prometheus metrics and generated JSON outputs
- Add tests for history compaction/rollups, derived serving status, template rendering, and nested output path handling

Currently being tested at https://status.eessi/test/.

Fixes #7