### PR TITLE
Add release installer workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,19 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: cvmfs-status-page-rust
-  TARGET: x86_64-unknown-linux-gnu
 
 jobs:
-  release:
-    name: Build and publish release
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -25,7 +32,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-gnu
+          targets: ${{ matrix.target }}
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2
@@ -62,18 +69,69 @@ jobs:
         run: cargo test --all-targets --all-features --locked
 
       - name: Build release binary
-        run: cargo build --release --locked --target "$TARGET"
+        run: cargo build --release --locked --target "${{ matrix.target }}"
 
       - name: Package release artifact
         run: |
           version="${GITHUB_REF_NAME#v}"
-          package="${BINARY_NAME}-${version}-${TARGET}"
+          target="${{ matrix.target }}"
+          package="${BINARY_NAME}-${version}-${target}"
           mkdir -p "dist/${package}"
-          cp "target/${TARGET}/release/${BINARY_NAME}" "dist/${package}/"
+          cp "target/${target}/release/${BINARY_NAME}" "dist/${package}/"
           cp README.md CHANGELOG.md "dist/${package}/"
           tar -C dist -czf "dist/${package}.tar.gz" "${package}"
           cd dist
           sha256sum "${package}.tar.gz" > "${package}.tar.gz.sha256"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub release
+    runs-on: ubuntu-24.04
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Validate tag matches Cargo version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          if [ "$version" != "$cargo_version" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${cargo_version}" >&2
+            exit 1
+          fi
+
+      - name: Extract release notes from changelog
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v version="$version" '
+            $0 ~ "^## \\[" version "\\]([[:space:]]|-|$)" { in_section = 1; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "CHANGELOG.md has no notes for ${version}" >&2
+            exit 1
+          fi
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
 
       - name: Publish GitHub release
         env:

--- a/README.md
+++ b/README.md
@@ -16,11 +16,48 @@ This repository contains the source code for an EESSI status page generator. The
 
 ## Installation
 
-### Prebuilt release
+### Install or update from a prebuilt release
 
-Prebuilt x86_64 Linux binaries are published on GitHub Releases for version tags.
-Download the `cvmfs-status-page-rust-<version>-x86_64-unknown-linux-gnu.tar.gz`
-asset for the release you want, then verify it with the matching `.sha256` file.
+Prebuilt Linux binaries are published on GitHub Releases for version tags.
+The release workflow publishes these targets:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+
+Install or update a specific release with:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/EESSI/cvmfs-status-page-rust/main/scripts/install.sh \
+  | sh -s -- --tag v0.0.1 --install-dir /path/to/bin
+```
+
+You can also install by version:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/EESSI/cvmfs-status-page-rust/main/scripts/install.sh \
+  | sh -s -- --version 0.0.1 --install-dir /path/to/bin
+```
+
+The install directory is required and must be writable by the current user. The
+script detects the Linux architecture, downloads the matching release asset and
+`.sha256` file, verifies the checksum, installs the binary atomically, and
+checks that `cvmfs-status-page-rust --version` reports the requested version.
+
+### Manual prebuilt install
+
+Download the release asset for your architecture from GitHub Releases:
+
+```sh
+version=0.0.1
+target=x86_64-unknown-linux-gnu
+package="cvmfs-status-page-rust-${version}-${target}"
+
+curl -fsSLO "https://github.com/EESSI/cvmfs-status-page-rust/releases/download/v${version}/${package}.tar.gz"
+curl -fsSLO "https://github.com/EESSI/cvmfs-status-page-rust/releases/download/v${version}/${package}.tar.gz.sha256"
+sha256sum -c "${package}.tar.gz.sha256"
+tar -xzf "${package}.tar.gz"
+install -m 0755 "${package}/cvmfs-status-page-rust" /path/to/bin/cvmfs-status-page-rust
+```
 
 ### Build from source
 
@@ -246,6 +283,9 @@ See [Prometheus metrics](docs/metrics.md) for the metric families, labels, statu
 ## Release Process
 
 Releases are created automatically by GitHub Actions when a version tag is pushed.
+The release workflow verifies the tag, runs formatting, clippy, and tests, then
+builds Linux release binaries for x86_64 and aarch64 before publishing the
+GitHub Release.
 
 1. Update `version` in `Cargo.toml`.
 2. Move the relevant entries in `CHANGELOG.md` from `Unreleased` to a new
@@ -258,7 +298,8 @@ git tag -a vx.y.z -m "Release vx.y.z"
 git push origin vx.y.z
 ```
 
-The release workflow verifies that the tag matches `Cargo.toml`, extracts the
-release notes from `CHANGELOG.md`, runs checks and tests, builds the
-`x86_64-unknown-linux-gnu` binary, and publishes a GitHub release with a tarball
-and SHA-256 checksum.
+5. Confirm that the release contains these assets:
+   - `cvmfs-status-page-rust-x.y.z-x86_64-unknown-linux-gnu.tar.gz`
+   - `cvmfs-status-page-rust-x.y.z-x86_64-unknown-linux-gnu.tar.gz.sha256`
+   - `cvmfs-status-page-rust-x.y.z-aarch64-unknown-linux-gnu.tar.gz`
+   - `cvmfs-status-page-rust-x.y.z-aarch64-unknown-linux-gnu.tar.gz.sha256`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+set -eu
+
+repo="EESSI/cvmfs-status-page-rust"
+binary_name="cvmfs-status-page-rust"
+tag=""
+version=""
+install_dir=""
+
+usage() {
+    cat <<EOF
+Usage:
+  install.sh --tag vX.Y.Z --install-dir DIR
+  install.sh --version X.Y.Z --install-dir DIR
+
+Options:
+  --tag TAG          Release tag to install, for example v0.0.1.
+  --version VERSION  Release version to install, for example 0.0.1.
+  --install-dir DIR  Directory where ${binary_name} should be installed.
+  --repo OWNER/REPO  GitHub repository to install from. Defaults to ${repo}.
+  -h, --help         Show this help.
+EOF
+}
+
+die() {
+    echo "install.sh: $*" >&2
+    exit 1
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --tag)
+            [ "$#" -ge 2 ] || die "--tag requires a value"
+            tag="$2"
+            shift 2
+            ;;
+        --version)
+            [ "$#" -ge 2 ] || die "--version requires a value"
+            version="$2"
+            shift 2
+            ;;
+        --install-dir)
+            [ "$#" -ge 2 ] || die "--install-dir requires a value"
+            install_dir="$2"
+            shift 2
+            ;;
+        --repo)
+            [ "$#" -ge 2 ] || die "--repo requires a value"
+            repo="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$install_dir" ] || die "--install-dir is required"
+
+if [ -n "$tag" ] && [ -n "$version" ]; then
+    die "use either --tag or --version, not both"
+fi
+
+if [ -n "$version" ]; then
+    case "$version" in
+        v*) die "--version should not include the leading v; use --tag for tags" ;;
+    esac
+    tag="v${version}"
+elif [ -n "$tag" ]; then
+    case "$tag" in
+        v*) version="${tag#v}" ;;
+        *) die "--tag must start with v, for example v0.0.1" ;;
+    esac
+else
+    die "one of --tag or --version is required"
+fi
+
+need_cmd uname
+
+os="$(uname -s)"
+[ "$os" = "Linux" ] || die "unsupported operating system: $os"
+
+need_cmd curl
+need_cmd tar
+need_cmd sha256sum
+need_cmd mktemp
+
+arch="$(uname -m)"
+case "$arch" in
+    x86_64|amd64)
+        target="x86_64-unknown-linux-gnu"
+        ;;
+    aarch64|arm64)
+        target="aarch64-unknown-linux-gnu"
+        ;;
+    *)
+        die "unsupported architecture: $arch"
+        ;;
+esac
+
+package="${binary_name}-${version}-${target}"
+archive="${package}.tar.gz"
+checksum="${archive}.sha256"
+base_url="https://github.com/${repo}/releases/download/${tag}"
+
+tmpdir="$(mktemp -d)"
+staged=""
+cleanup() {
+    if [ -n "$staged" ] && [ -e "$staged" ]; then
+        rm -f "$staged"
+    fi
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT HUP TERM
+
+echo "Downloading ${repo} ${tag} for ${target}"
+curl -fsSL "${base_url}/${archive}" -o "${tmpdir}/${archive}"
+curl -fsSL "${base_url}/${checksum}" -o "${tmpdir}/${checksum}"
+
+(
+    cd "$tmpdir"
+    sha256sum -c "$checksum"
+)
+
+tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
+[ -x "${tmpdir}/${package}/${binary_name}" ] || die "archive does not contain executable ${binary_name}"
+
+mkdir -p "$install_dir"
+[ -d "$install_dir" ] || die "install directory is not a directory: $install_dir"
+[ -w "$install_dir" ] || die "install directory is not writable: $install_dir"
+
+destination="${install_dir%/}/${binary_name}"
+staged="$(mktemp "${install_dir%/}/.${binary_name}.tmp.XXXXXX")"
+cp "${tmpdir}/${package}/${binary_name}" "$staged"
+chmod 0755 "$staged"
+
+staged_version="$("$staged" --version 2>/dev/null || true)"
+case "$staged_version" in
+    "${binary_name} ${version}") ;;
+    *)
+        die "downloaded binary reported unexpected version: ${staged_version}"
+        ;;
+esac
+
+mv "$staged" "$destination"
+
+echo "Installed ${binary_name} ${version} to ${destination}"


### PR DESCRIPTION
## Summary
- build tagged releases for x86_64 and aarch64 Linux targets before publishing
- add a curl-friendly installer/updater with checksum and version validation
- document install/update commands and the release checklist

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- sh -n scripts/install.sh
- shellcheck scripts/install.sh
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-targets --all-features --locked